### PR TITLE
(De)serialize inner structures as JSON

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -2088,7 +2088,7 @@ mod tests {
     async fn test_caching_performance() {
         let runs = 2500;
         let edit_rate = 25;
-        let timeout = 37;
+        let timeout = 45;
         #[cfg(feature = "rusqlite")]
         perform_caching(":memory:", runs, edit_rate, timeout).await;
         #[cfg(feature = "tokio-postgres")]

--- a/src/any.rs
+++ b/src/any.rs
@@ -296,6 +296,7 @@ mod tests {
     use super::*;
     use crate::{
         core::{CachingStrategy, QUERY_CACHE_TABLE, TABLE_CACHE_TABLE},
+        db_row,
         db_value::{ColumnMap, DbRow, DbValue, StringRow},
         memory::{
             clear_memory_query_cache, clear_memory_table_cache, clear_meta_cache,
@@ -303,7 +304,6 @@ mod tests {
         },
         params,
     };
-    use indexmap::indexmap as db_row;
     use rand::{
         SeedableRng as _,
         distr::{Distribution as _, Uniform},

--- a/src/any.rs
+++ b/src/any.rs
@@ -956,7 +956,7 @@ mod tests {
                 },
                 db_row! {
                     "float_value" => DbValue::Null,
-                    "int_value" => DbValue::from(1_i64),
+                    "int_value" => 1_i64,
                 }
             ]
         );

--- a/src/any.rs
+++ b/src/any.rs
@@ -374,10 +374,10 @@ mod tests {
         );
 
         let row: DbRow = pool.query_row(&select_sql, &["foo"]).await.unwrap();
-        assert_eq!(row, db_row! {"value".into() => DbValue::from("foo")});
+        assert_eq!(row, db_row! {"value" => "foo",});
 
         let rows: Vec<DbRow> = pool.query(&select_sql, &["foo"]).await.unwrap();
-        assert_eq!(rows, [db_row! {"value".into() => DbValue::from("foo")}]);
+        assert_eq!(rows, [db_row! {"value" => "foo",}]);
 
         // Clean up:
         pool.drop_table("test_table_text").await.unwrap();
@@ -497,10 +497,10 @@ mod tests {
         assert_eq!(vec!["1.05".to_owned()], strings);
 
         let row: DbRow = pool.query_row(&select_sql, &[1.0_f64]).await.unwrap();
-        assert_eq!(row, db_row! {"value".into() => DbValue::from(1.05)});
+        assert_eq!(row, db_row! {"value" => 1.05,});
 
         let rows: Vec<DbRow> = pool.query(&select_sql, &[1.0_f64]).await.unwrap();
-        assert_eq!(rows, [db_row! {"value".into() => DbValue::from(1.05)}]);
+        assert_eq!(rows, [db_row! {"value" => 1.05,}]);
 
         // FLOAT4
         pool.execute_batch(&format!(
@@ -615,19 +615,19 @@ mod tests {
         assert_eq!(
             row,
             db_row! {
-                "text_value".into() => DbValue::from("foo"),
-                "alt_text_value".into() => DbValue::Null,
-                "float_value".into() => DbValue::from(1.05),
-                "alt_float_value".into() => DbValue::Null,
-                "int_value".into() => DbValue::from(1_i64),
-                "alt_int_value".into() => DbValue::Null,
-                "bool_value".into() => match pool.kind() {
+                "text_value" => "foo",
+                "alt_text_value" => DbValue::Null,
+                "float_value" => 1.05,
+                "alt_float_value" => DbValue::Null,
+                "int_value" => 1_i64,
+                "alt_int_value" => DbValue::Null,
+                "bool_value" => match pool.kind() {
                     DbKind::SQLite => DbValue::from(1_i64),
                     DbKind::PostgreSQL => DbValue::from(true),
                 },
-                "alt_bool_value".into() => DbValue::Null,
-                "numeric_value".into() => DbValue::from(1_i64),
-                "alt_numeric_value".into() => DbValue::Null,
+                "alt_bool_value" => DbValue::Null,
+                "numeric_value" => 1_i64,
+                "alt_numeric_value" => DbValue::Null,
             }
         );
 
@@ -635,19 +635,19 @@ mod tests {
         assert_eq!(
             rows,
             [db_row! {
-                "text_value".into() => DbValue::from("foo"),
-                "alt_text_value".into() => DbValue::Null,
-                "float_value".into() => DbValue::from(1.05),
-                "alt_float_value".into() => DbValue::Null,
-                "int_value".into() => DbValue::from(1_i64),
-                "alt_int_value".into() => DbValue::Null,
-                "bool_value".into() => match pool.kind() {
+                "text_value" => "foo",
+                "alt_text_value" => DbValue::Null,
+                "float_value" => 1.05,
+                "alt_float_value" => DbValue::Null,
+                "int_value" => 1_i64,
+                "alt_int_value" => DbValue::Null,
+                "bool_value" => match pool.kind() {
                     DbKind::SQLite => DbValue::from(1_i64),
                     DbKind::PostgreSQL => DbValue::from(true),
                 },
-                "alt_bool_value".into() => DbValue::Null,
-                "numeric_value".into() => DbValue::from(1_i64),
-                "alt_numeric_value".into() => DbValue::Null,
+                "alt_bool_value" => DbValue::Null,
+                "numeric_value" => 1_i64,
+                "alt_numeric_value" => DbValue::Null,
             }]
         );
 
@@ -815,10 +815,10 @@ mod tests {
             "test_insert",
             &["text_value", "int_value", "bool_value"],
             &[
-                &db_row! {"text_value".into() => DbValue::from("TEXT")},
+                &db_row! {"text_value" => "TEXT",},
                 &db_row! {
-                    "int_value".into() => DbValue::from(1_i64),
-                    "bool_value".into() => match pool.kind() {
+                    "int_value" => 1_i64,
+                    "bool_value" => match pool.kind() {
                         DbKind::SQLite => DbValue::from(1_i64),
                         DbKind::PostgreSQL => DbValue::from(true),
                     },
@@ -837,18 +837,18 @@ mod tests {
             rows,
             [
                 db_row! {
-                    "text_value".into() => DbValue::from("TEXT"),
-                    "alt_text_value".into() => DbValue::Null,
-                    "float_value".into() => DbValue::Null,
-                    "int_value".into() => DbValue::Null,
-                    "bool_value".into() => DbValue::Null,
+                    "text_value" => "TEXT",
+                    "alt_text_value" => DbValue::Null,
+                    "float_value" => DbValue::Null,
+                    "int_value" => DbValue::Null,
+                    "bool_value" => DbValue::Null,
                 },
                 db_row! {
-                    "text_value".into() => DbValue::Null,
-                    "alt_text_value".into() => DbValue::Null,
-                    "float_value".into() => DbValue::Null,
-                    "int_value".into() => DbValue::from(1_i64),
-                    "bool_value".into() => match pool.kind() {
+                    "text_value" => DbValue::Null,
+                    "alt_text_value" => DbValue::Null,
+                    "float_value" => DbValue::Null,
+                    "int_value" => 1_i64,
+                    "bool_value" => match pool.kind() {
                         DbKind::SQLite => DbValue::from(1_i64),
                         DbKind::PostgreSQL => DbValue::from(true),
                     },
@@ -896,10 +896,10 @@ mod tests {
                 "test_insert_returning",
                 &["text_value", "int_value", "bool_value"],
                 &[
-                    &db_row! {"text_value".into() => DbValue::from("TEXT")},
+                    &db_row! {"text_value" => "TEXT",},
                     &db_row! {
-                        "int_value".into() => DbValue::from(1_i64),
-                        "bool_value".into() => DbValue::from(true)
+                        "int_value" => 1_i64,
+                        "bool_value" => true,
                     },
                 ],
                 &[],
@@ -910,21 +910,21 @@ mod tests {
             rows,
             [
                 db_row! {
-                    "text_value".into() => DbValue::from("TEXT"),
-                    "alt_text_value".into() => DbValue::Null,
-                    "float_value".into() => DbValue::Null,
-                    "int_value".into() => DbValue::Null,
-                    "bool_value".into() => DbValue::Null,
+                    "text_value" => "TEXT",
+                    "alt_text_value" => DbValue::Null,
+                    "float_value" => DbValue::Null,
+                    "int_value" => DbValue::Null,
+                    "bool_value" => DbValue::Null,
                 },
                 db_row! {
-                    "text_value".into() => DbValue::Null,
-                    "alt_text_value".into() => DbValue::Null,
-                    "float_value".into() => DbValue::Null,
-                    "int_value".into() => DbValue::from(1_i64),
-                    "bool_value".into() => match pool.kind() {
+                    "text_value" => DbValue::Null,
+                    "alt_text_value" => DbValue::Null,
+                    "float_value" => DbValue::Null,
+                    "int_value" => 1_i64,
+                    "bool_value" => match pool.kind() {
                         DbKind::SQLite => DbValue::from(1_i64),
                         DbKind::PostgreSQL => DbValue::from(true),
-                    }
+                    },
                 }
             ]
         );
@@ -935,10 +935,12 @@ mod tests {
                 "test_insert_returning",
                 &["text_value", "int_value", "bool_value"],
                 &[
-                    &db_row! {"text_value".into() => DbValue::from("TEXT")},
                     &db_row! {
-                        "int_value".into() => DbValue::from(1_i64),
-                        "bool_value".into() => DbValue::from(true)
+                        "text_value" => "TEXT",
+                    },
+                    &db_row! {
+                        "int_value" => 1_i64,
+                        "bool_value" => true,
                     },
                 ],
                 &["int_value", "float_value"],
@@ -949,12 +951,12 @@ mod tests {
             rows,
             [
                 db_row! {
-                    "float_value".into() => DbValue::Null,
-                    "int_value".into() => DbValue::Null,
+                    "float_value" => DbValue::Null,
+                    "int_value" => DbValue::Null,
                 },
                 db_row! {
-                    "float_value".into() => DbValue::Null,
-                    "int_value".into() => DbValue::from(1_i64),
+                    "float_value" => DbValue::Null,
+                    "int_value" => DbValue::from(1_i64),
                 }
             ]
         );
@@ -1092,9 +1094,9 @@ mod tests {
             "test_update",
             &["foo"],
             &[
-                &db_row! {"foo".into() => DbValue::from(1_i64)},
-                &db_row! {"foo".into() => DbValue::from(2_i64)},
-                &db_row! {"foo".into() => DbValue::from(3_i64)},
+                &db_row! {"foo" => 1_i64,},
+                &db_row! {"foo" => 2_i64,},
+                &db_row! {"foo" => 3_i64,},
             ],
         )
         .await
@@ -1105,25 +1107,25 @@ mod tests {
             &["foo", "bar", "car", "dar", "ear"],
             &[
                 &db_row! {
-                    "foo".into() => DbValue::from(1_i64),
-                    "bar".into() => DbValue::from(10_i64),
-                    "car".into() => DbValue::from(11_i64),
-                    "dar".into() => DbValue::from(12_i64),
-                    "ear".into() => DbValue::from(13_i64),
+                    "foo" => 1_i64,
+                    "bar" => 10_i64,
+                    "car" => 11_i64,
+                    "dar" => 12_i64,
+                    "ear" => 13_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(2_i64),
-                    "bar".into() => DbValue::from(14_i64),
-                    "car".into() => DbValue::from(15_i64),
-                    "dar".into() => DbValue::from(16_i64),
-                    "ear".into() => DbValue::from(17_i64),
+                    "foo" => 2_i64,
+                    "bar" => 14_i64,
+                    "car" => 15_i64,
+                    "dar" => 16_i64,
+                    "ear" => 17_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(3_i64),
-                    "bar".into() => DbValue::from(18_i64),
-                    "car".into() => DbValue::from(19_i64),
-                    "dar".into() => DbValue::from(20_i64),
-                    "ear".into() => DbValue::from(21_i64),
+                    "foo" => 3_i64,
+                    "bar" => 18_i64,
+                    "car" => 19_i64,
+                    "dar" => 20_i64,
+                    "ear" => 21_i64,
                 },
             ],
         )
@@ -1135,25 +1137,25 @@ mod tests {
             rows,
             [
                 db_row! {
-                    "foo".into() => DbValue::from(1_i64),
-                    "bar".into() => DbValue::from(10_i64),
-                    "car".into() => DbValue::from(11_i64),
-                    "dar".into() => DbValue::from(12_i64),
-                    "ear".into() => DbValue::from(13_i64),
+                    "foo" => 1_i64,
+                    "bar" => 10_i64,
+                    "car" => 11_i64,
+                    "dar" => 12_i64,
+                    "ear" => 13_i64,
                 },
                 db_row! {
-                    "foo".into() => DbValue::from(2_i64),
-                    "bar".into() => DbValue::from(14_i64),
-                    "car".into() => DbValue::from(15_i64),
-                    "dar".into() => DbValue::from(16_i64),
-                    "ear".into() => DbValue::from(17_i64),
+                    "foo" => 2_i64,
+                    "bar" => 14_i64,
+                    "car" => 15_i64,
+                    "dar" => 16_i64,
+                    "ear" => 17_i64,
                 },
                 db_row! {
-                    "foo".into() => DbValue::from(3_i64),
-                    "bar".into() => DbValue::from(18_i64),
-                    "car".into() => DbValue::from(19_i64),
-                    "dar".into() => DbValue::from(20_i64),
-                    "ear".into() => DbValue::from(21_i64),
+                    "foo" => 3_i64,
+                    "bar" => 18_i64,
+                    "car" => 19_i64,
+                    "dar" => 20_i64,
+                    "ear" => 21_i64,
                 },
             ]
         );
@@ -1198,16 +1200,16 @@ mod tests {
             &["foo", "bar", "car", "dar", "ear"],
             &[
                 &db_row! {
-                    "foo".into() => DbValue::from(1_i64),
-                    "bar".into() => DbValue::from(1_i64)
+                    "foo" => 1_i64,
+                    "bar" => 1_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(2_i64),
-                    "bar".into() => DbValue::from(2_i64),
+                    "foo" => 2_i64,
+                    "bar" => 2_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(3_i64),
-                    "bar".into() => DbValue::from(3_i64),
+                    "foo" => 3_i64,
+                    "bar" => 3_i64,
                 },
             ],
         )
@@ -1218,19 +1220,19 @@ mod tests {
             assert!(rows.iter().all(|row| {
                 [
                     db_row! {
-                        "car".into() => DbValue::from(10_i64),
-                        "dar".into() => DbValue::from(11_i64),
-                        "ear".into() => DbValue::from(12_i64),
+                        "car" => 10_i64,
+                        "dar" => 11_i64,
+                        "ear" => 12_i64,
                     },
                     db_row! {
-                        "car".into() => DbValue::from(13_i64),
-                        "dar".into() => DbValue::from(14_i64),
-                        "ear".into() => DbValue::from(15_i64),
+                        "car" => 13_i64,
+                        "dar" => 14_i64,
+                        "ear" => 15_i64,
                     },
                     db_row! {
-                        "car".into() => DbValue::from(16_i64),
-                        "dar".into() => DbValue::from(17_i64),
-                        "ear".into() => DbValue::from(18_i64),
+                        "car" => 16_i64,
+                        "dar" => 17_i64,
+                        "ear" => 18_i64,
                     },
                 ]
                 .contains(&row)
@@ -1244,25 +1246,25 @@ mod tests {
                     &["foo", "bar", "car", "dar", "ear"],
                     &[
                         &db_row! {
-                            "foo".into() => DbValue::from(1_i64),
-                            "bar".into() => DbValue::from(1_i64),
-                            "car".into() => DbValue::from(10_i64),
-                            "dar".into() => DbValue::from(11_i64),
-                            "ear".into() => DbValue::from(12_i64),
+                            "foo" => 1_i64,
+                            "bar" => 1_i64,
+                            "car" => 10_i64,
+                            "dar" => 11_i64,
+                            "ear" => 12_i64,
                         },
                         &db_row! {
-                            "foo".into() => DbValue::from(2_i64),
-                            "bar".into() => DbValue::from(2_i64),
-                            "car".into() => DbValue::from(13_i64),
-                            "dar".into() => DbValue::from(14_i64),
-                            "ear".into() => DbValue::from(15_i64),
+                            "foo" => 2_i64,
+                            "bar" => 2_i64,
+                            "car" => 13_i64,
+                            "dar" => 14_i64,
+                            "ear" => 15_i64,
                         },
                         &db_row! {
-                            "foo".into() => DbValue::from(3_i64),
-                            "bar".into() => DbValue::from(3_i64),
-                            "car".into() => DbValue::from(16_i64),
-                            "dar".into() => DbValue::from(17_i64),
-                            "ear".into() => DbValue::from(18_i64),
+                            "foo" => 3_i64,
+                            "bar" => 3_i64,
+                            "car" => 16_i64,
+                            "dar" => 17_i64,
+                            "ear" => 18_i64,
                         },
                     ],
                     &["car", "dar", "ear"],
@@ -1282,16 +1284,16 @@ mod tests {
             &["foo", "bar"],
             &[
                 &db_row! {
-                    "foo".into() => DbValue::from(1_i64),
-                    "bar".into() => DbValue::from(1_i64),
+                    "foo" => 1_i64,
+                    "bar" => 1_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(2_i64),
-                    "bar".into() => DbValue::from(2_i64),
+                    "foo" => 2_i64,
+                    "bar" => 2_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(3_i64),
-                    "bar".into() => DbValue::from(3_i64),
+                    "foo" => 3_i64,
+                    "bar" => 3_i64,
                 },
             ],
         )
@@ -1305,25 +1307,25 @@ mod tests {
                     &["foo", "bar", "car", "dar", "ear"],
                     &[
                         &db_row! {
-                            "ear".into() => DbValue::from(15_i64),
-                            "bar".into() => DbValue::from(2_i64),
-                            "car".into() => DbValue::from(13_i64),
-                            "dar".into() => DbValue::from(14_i64),
-                            "foo".into() => DbValue::from(2_i64),
+                            "ear" => 15_i64,
+                            "bar" => 2_i64,
+                            "car" => 13_i64,
+                            "dar" => 14_i64,
+                            "foo" => 2_i64,
                         },
                         &db_row! {
-                            "foo".into() => DbValue::from(1_i64),
-                            "car".into() => DbValue::from(10_i64),
-                            "bar".into() => DbValue::from(1_i64),
-                            "ear".into() => DbValue::from(12_i64),
-                            "dar".into() => DbValue::from(11_i64),
+                            "foo" => 1_i64,
+                            "car" => 10_i64,
+                            "bar" => 1_i64,
+                            "ear" => 12_i64,
+                            "dar" => 11_i64,
                         },
                         &db_row! {
-                            "car".into() => DbValue::from(16_i64),
-                            "dar".into() => DbValue::from(17_i64),
-                            "ear".into() => DbValue::from(18_i64),
-                            "bar".into() => DbValue::from(3_i64),
-                            "foo".into() => DbValue::from(3_i64),
+                            "car" => 16_i64,
+                            "dar" => 17_i64,
+                            "ear" => 18_i64,
+                            "bar" => 3_i64,
+                            "foo" => 3_i64,
                         },
                     ],
                     &["car", "dar", "ear"],
@@ -1340,25 +1342,25 @@ mod tests {
         assert!(rows.iter().all(|row| {
             [
                 db_row! {
-                    "foo".into() => DbValue::from(1_i64),
-                    "bar".into() => DbValue::from(1_i64),
-                    "car".into() => DbValue::from(10_i64),
-                    "dar".into() => DbValue::from(11_i64),
-                    "ear".into() => DbValue::from(12_i64),
+                    "foo" => 1_i64,
+                    "bar" => 1_i64,
+                    "car" => 10_i64,
+                    "dar" => 11_i64,
+                    "ear" => 12_i64,
                 },
                 db_row! {
-                    "foo".into() => DbValue::from(2_i64),
-                    "bar".into() => DbValue::from(2_i64),
-                    "car".into() => DbValue::from(13_i64),
-                    "dar".into() => DbValue::from(14_i64),
-                    "ear".into() => DbValue::from(15_i64),
+                    "foo" => 2_i64,
+                    "bar" => 2_i64,
+                    "car" => 13_i64,
+                    "dar" => 14_i64,
+                    "ear" => 15_i64,
                 },
                 db_row! {
-                    "foo".into() => DbValue::from(3_i64),
-                    "bar".into() => DbValue::from(3_i64),
-                    "car".into() => DbValue::from(16_i64),
-                    "dar".into() => DbValue::from(17_i64),
-                    "ear".into() => DbValue::from(18_i64),
+                    "foo" => 3_i64,
+                    "bar" => 3_i64,
+                    "car" => 16_i64,
+                    "dar" => 17_i64,
+                    "ear" => 18_i64,
                 },
             ]
             .contains(&row)
@@ -1402,9 +1404,15 @@ mod tests {
             "test_upsert",
             &["foo"],
             &[
-                &db_row! {"foo".into() => DbValue::from(1_i64)},
-                &db_row! {"foo".into() => DbValue::from(2_i64)},
-                &db_row! {"foo".into() => DbValue::from(3_i64)},
+                &db_row! {
+                    "foo" => 1_i64,
+                },
+                &db_row! {
+                    "foo" => 2_i64,
+                },
+                &db_row! {
+                    "foo" => 3_i64,
+                },
             ],
         )
         .await
@@ -1415,25 +1423,25 @@ mod tests {
             &["foo", "bar", "car", "dar", "ear"],
             &[
                 &db_row! {
-                    "foo".into() => DbValue::from(1_i64),
-                    "bar".into() => DbValue::from(10_i64),
-                    "car".into() => DbValue::from(11_i64),
-                    "dar".into() => DbValue::from(12_i64),
-                    "ear".into() => DbValue::from(13_i64),
+                    "foo" => 1_i64,
+                    "bar" => 10_i64,
+                    "car" => 11_i64,
+                    "dar" => 12_i64,
+                    "ear" => 13_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(2_i64),
-                    "bar".into() => DbValue::from(14_i64),
-                    "car".into() => DbValue::from(15_i64),
-                    "dar".into() => DbValue::from(16_i64),
-                    "ear".into() => DbValue::from(17_i64),
+                    "foo" => 2_i64,
+                    "bar" => 14_i64,
+                    "car" => 15_i64,
+                    "dar" => 16_i64,
+                    "ear" => 17_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(3_i64),
-                    "bar".into() => DbValue::from(18_i64),
-                    "car".into() => DbValue::from(19_i64),
-                    "dar".into() => DbValue::from(20_i64),
-                    "ear".into() => DbValue::from(21_i64),
+                    "foo" => 3_i64,
+                    "bar" => 18_i64,
+                    "car" => 19_i64,
+                    "dar" => 20_i64,
+                    "ear" => 21_i64,
                 },
             ],
         )
@@ -1445,25 +1453,25 @@ mod tests {
             rows,
             [
                 db_row! {
-                    "foo".into() => DbValue::from(1_i64),
-                    "bar".into() => DbValue::from(10_i64),
-                    "car".into() => DbValue::from(11_i64),
-                    "dar".into() => DbValue::from(12_i64),
-                    "ear".into() => DbValue::from(13_i64),
+                    "foo" => 1_i64,
+                    "bar" => 10_i64,
+                    "car" => 11_i64,
+                    "dar" => 12_i64,
+                    "ear" => 13_i64,
                 },
                 db_row! {
-                    "foo".into() => DbValue::from(2_i64),
-                    "bar".into() => DbValue::from(14_i64),
-                    "car".into() => DbValue::from(15_i64),
-                    "dar".into() => DbValue::from(16_i64),
-                    "ear".into() => DbValue::from(17_i64),
+                    "foo" => 2_i64,
+                    "bar" => 14_i64,
+                    "car" => 15_i64,
+                    "dar" => 16_i64,
+                    "ear" => 17_i64,
                 },
                 db_row! {
-                    "foo".into() => DbValue::from(3_i64),
-                    "bar".into() => DbValue::from(18_i64),
-                    "car".into() => DbValue::from(19_i64),
-                    "dar".into() => DbValue::from(20_i64),
-                    "ear".into() => DbValue::from(21_i64),
+                    "foo" => 3_i64,
+                    "bar" => 18_i64,
+                    "car" => 19_i64,
+                    "dar" => 20_i64,
+                    "ear" => 21_i64,
                 },
             ]
         );
@@ -1508,16 +1516,16 @@ mod tests {
             &["foo", "bar", "car", "dar", "ear"],
             &[
                 &db_row! {
-                    "foo".into() => DbValue::from(1_i64),
-                    "bar".into() => DbValue::from(1_i64),
+                    "foo" => 1_i64,
+                    "bar" => 1_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(2_i64),
-                    "bar".into() => DbValue::from(2_i64),
+                    "foo" => 2_i64,
+                    "bar" => 2_i64,
                 },
                 &db_row! {
-                    "foo".into() => DbValue::from(3_i64),
-                    "bar".into() => DbValue::from(3_i64),
+                    "foo" => 3_i64,
+                    "bar" => 3_i64,
                 },
             ],
         )
@@ -1530,25 +1538,25 @@ mod tests {
                 &["foo", "bar", "car", "dar", "ear"],
                 &[
                     &db_row! {
-                        "foo".into() => DbValue::from(1_i64),
-                        "bar".into() => DbValue::from(1_i64),
-                        "car".into() => DbValue::from(10_i64),
-                        "dar".into() => DbValue::from(11_i64),
-                        "ear".into() => DbValue::from(12_i64),
+                        "foo" => 1_i64,
+                        "bar" => 1_i64,
+                        "car" => 10_i64,
+                        "dar" => 11_i64,
+                        "ear" => 12_i64,
                     },
                     &db_row! {
-                        "foo".into() => DbValue::from(2_i64),
-                        "bar".into() => DbValue::from(2_i64),
-                        "car".into() => DbValue::from(13_i64),
-                        "dar".into() => DbValue::from(14_i64),
-                        "ear".into() => DbValue::from(15_i64),
+                        "foo" => 2_i64,
+                        "bar" => 2_i64,
+                        "car" => 13_i64,
+                        "dar" => 14_i64,
+                        "ear" => 15_i64,
                     },
                     &db_row! {
-                        "foo".into() => DbValue::from(3_i64),
-                        "bar".into() => DbValue::from(3_i64),
-                        "car".into() => DbValue::from(16_i64),
-                        "dar".into() => DbValue::from(17_i64),
-                        "ear".into() => DbValue::from(18_i64),
+                        "foo" => 3_i64,
+                        "bar" => 3_i64,
+                        "car" => 16_i64,
+                        "dar" => 17_i64,
+                        "ear" => 18_i64,
                     },
                 ],
                 &["car", "dar", "ear"],
@@ -1558,19 +1566,19 @@ mod tests {
         assert!(rows.iter().all(|row| {
             [
                 db_row! {
-                    "car".into() => DbValue::from(10_i64),
-                    "dar".into() => DbValue::from(11_i64),
-                    "ear".into() => DbValue::from(12_i64),
+                    "car" => 10_i64,
+                    "dar" => 11_i64,
+                    "ear" => 12_i64,
                 },
                 db_row! {
-                    "car".into() => DbValue::from(13_i64),
-                    "dar".into() => DbValue::from(14_i64),
-                    "ear".into() => DbValue::from(15_i64),
+                    "car" => 13_i64,
+                    "dar" => 14_i64,
+                    "ear" => 15_i64,
                 },
                 db_row! {
-                    "car".into() => DbValue::from(16_i64),
-                    "dar".into() => DbValue::from(17_i64),
-                    "ear".into() => DbValue::from(18_i64),
+                    "car" => 16_i64,
+                    "dar" => 17_i64,
+                    "ear" => 18_i64,
                 },
             ]
             .contains(&row)
@@ -1671,10 +1679,10 @@ mod tests {
             &["value"],
             &[
                 &db_row! {
-                    "value".into() => DbValue::from("alpha"),
+                    "value" => "alpha",
                 },
                 &db_row! {
-                    "value".into() => DbValue::from("beta"),
+                    "value" => "beta",
                 },
             ],
         )
@@ -1698,8 +1706,12 @@ mod tests {
         assert_eq!(
             rows,
             vec![
-                db_row! {"value".into() => DbValue::from("alpha")},
-                db_row! {"value".into() => DbValue::from("beta")},
+                db_row! {
+                    "value" => "alpha",
+                },
+                db_row! {
+                    "value" => "beta",
+                },
             ]
         );
 
@@ -1720,8 +1732,12 @@ mod tests {
         assert_eq!(
             rows,
             vec![
-                db_row! {"value".into() => DbValue::from("alpha")},
-                db_row! {"value".into() => DbValue::from("beta")},
+                db_row! {
+                    "value" => "alpha",
+                },
+                db_row! {
+                    "value" => "beta",
+                },
             ]
         );
 
@@ -1729,8 +1745,12 @@ mod tests {
             "test_table_caching_1",
             &["value"],
             &[
-                &db_row! {"value".into() => DbValue::from("gamma")},
-                &db_row! {"value".into() => DbValue::from("delta")},
+                &db_row! {
+                    "value" => "gamma",
+                },
+                &db_row! {
+                    "value" => "delta",
+                },
             ],
         )
         .await
@@ -1759,10 +1779,18 @@ mod tests {
         assert_eq!(
             rows,
             vec![
-                db_row! {"value".into() => DbValue::from("alpha")},
-                db_row! {"value".into() => DbValue::from("beta")},
-                db_row! {"value".into() => DbValue::from("gamma")},
-                db_row! {"value".into() => DbValue::from("delta")},
+                db_row! {
+                    "value" => "alpha",
+                },
+                db_row! {
+                    "value" => "beta",
+                },
+                db_row! {
+                    "value" => "gamma",
+                },
+                db_row! {
+                    "value" => "delta",
+                },
             ]
         );
 
@@ -1778,10 +1806,18 @@ mod tests {
         assert_eq!(
             rows,
             vec![
-                db_row! {"value".into() => DbValue::from("alpha")},
-                db_row! {"value".into() => DbValue::from("beta")},
-                db_row! {"value".into() => DbValue::from("gamma")},
-                db_row! {"value".into() => DbValue::from("delta")},
+                db_row! {
+                    "value" => "alpha",
+                },
+                db_row! {
+                    "value" => "beta",
+                },
+                db_row! {
+                    "value" => "gamma",
+                },
+                db_row! {
+                    "value" => "delta",
+                },
             ]
         );
 
@@ -1845,12 +1881,24 @@ mod tests {
         assert_eq!(
             rows,
             vec![
-                db_row! {"value".into() => DbValue::from("alpha")},
-                db_row! {"value".into() => DbValue::from("beta")},
-                db_row! {"value".into() => DbValue::from("gamma")},
-                db_row! {"value".into() => DbValue::from("delta")},
-                db_row! {"value".into() => DbValue::from("rho")},
-                db_row! {"value".into() => DbValue::from("sigma")},
+                db_row! {
+                    "value" => "alpha",
+                },
+                db_row! {
+                    "value" => "beta",
+                },
+                db_row! {
+                    "value" => "gamma",
+                },
+                db_row! {
+                    "value" => "delta",
+                },
+                db_row! {
+                    "value" => "rho",
+                },
+                db_row! {
+                    "value" => "sigma",
+                },
             ]
         );
 
@@ -1975,8 +2023,8 @@ mod tests {
             "test_vcaching_table",
             &["foo", "bar"],
             &[&db_row! {
-                "foo".into() => DbValue::from(2_u64),
-                "bar".into() => DbValue::from(2_u64),
+                "foo" => 2_u64,
+                "bar" => 2_u64,
             }],
         )
         .await
@@ -2048,8 +2096,8 @@ mod tests {
             "test_vcaching_table",
             &["foo", "bar"],
             &[&db_row! {
-                "foo".into() => DbValue::from(27_u64),
-                "bar".into() => DbValue::from(27_u64),
+                "foo" => 27_u64,
+                "bar" => 27_u64,
             }],
         )
         .await

--- a/src/core.rs
+++ b/src/core.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 use async_trait::async_trait;
+use serde::ser;
 use std::{
     collections::HashSet,
     fmt::Display,
@@ -46,9 +47,20 @@ pub enum DbError {
     DatatypeError(String),
     /// An error that occurred while attempting to parse a SQL string or value.
     ParseError(String),
+    /// TODO: Add docstring
+    SerdeError(String),
 }
 
 impl std::error::Error for DbError {}
+
+impl ser::Error for DbError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        DbError::SerdeError(msg.to_string())
+    }
+}
 
 impl std::fmt::Display for DbError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -58,7 +70,8 @@ impl std::fmt::Display for DbError {
             | DbError::InputError(err)
             | DbError::DatabaseError(err)
             | DbError::DatatypeError(err)
-            | DbError::ParseError(err) => write!(f, "{err}"),
+            | DbError::ParseError(err)
+            | DbError::SerdeError(err) => write!(f, "{err}"),
         }
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use serde::ser;
+use serde::{de, ser};
 use std::{
     collections::HashSet,
     fmt::Display,
@@ -54,6 +54,15 @@ pub enum DbError {
 impl std::error::Error for DbError {}
 
 impl ser::Error for DbError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        DbError::SerdeError(msg.to_string())
+    }
+}
+
+impl de::Error for DbError {
     fn custom<T>(msg: T) -> Self
     where
         T: Display,

--- a/src/core.rs
+++ b/src/core.rs
@@ -608,7 +608,7 @@ pub trait DbQuery {
                 let rows: Vec<DbRow> = self.query_no_cache(&sql, &[&table_param]).await?;
                 match rows.first() {
                     Some(row) => match row.get("last_verified") {
-                        Some(value) if *value == DbValue::Null => Ok(0),
+                        Some(value) if value == DbValue::Null => Ok(0),
                         Some(value) => Ok(value.try_into()?),
                         None => Err(DbError::DataError(format!(
                             "No 'last_verified' found in row: {row:?}"

--- a/src/core.rs
+++ b/src/core.rs
@@ -47,7 +47,7 @@ pub enum DbError {
     DatatypeError(String),
     /// An error that occurred while attempting to parse a SQL string or value.
     ParseError(String),
-    /// TODO: Add docstring
+    /// An error that occurred during serialization or deserialization.
     SerdeError(String),
 }
 

--- a/src/db_value.rs
+++ b/src/db_value.rs
@@ -14,58 +14,6 @@ pub type JsonRow = JsonMap<String, JsonValue>;
 pub type StringRow = IndexMap<String, String>;
 pub type ColumnMap = IndexMap<String, String>;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
-pub struct DbRow {
-    pub map: IndexMap<String, DbValue>,
-}
-
-impl Deref for DbRow {
-    type Target = IndexMap<String, DbValue>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.map
-    }
-}
-
-impl DerefMut for DbRow {
-    fn deref_mut(&mut self) -> &mut IndexMap<String, DbValue> {
-        &mut self.map
-    }
-}
-
-impl DbRow {
-    pub fn new() -> Self {
-        DbRow {
-            map: IndexMap::new(),
-        }
-    }
-
-    pub fn insert(&mut self, key: String, value: DbValue) {
-        self.map.insert(key, value);
-    }
-
-    pub fn get(&self, key: &str) -> Option<DbValue> {
-        self.map.get(key).cloned()
-    }
-}
-
-impl IntoIterator for DbRow {
-    type Item = (String, DbValue);
-    type IntoIter = indexmap::map::IntoIter<String, DbValue>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.map.into_iter()
-    }
-}
-
-impl FromIterator<(String, DbValue)> for DbRow {
-    fn from_iter<I: IntoIterator<Item = (String, DbValue)>>(iter: I) -> Self {
-        DbRow {
-            map: iter.into_iter().collect(),
-        }
-    }
-}
-
 /// Database Value types
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum DbValue {
@@ -809,6 +757,61 @@ impl<T: IntoDbValue> IntoDbParams for Vec<T> {
             .map(|i| i.into_db_value())
             .collect::<Vec<_>>();
         DbParams::Positional(values)
+    }
+}
+
+// Database rows
+
+/// A row of database values indexed by column name.
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+pub struct DbRow {
+    pub map: IndexMap<String, DbValue>,
+}
+
+impl Deref for DbRow {
+    type Target = IndexMap<String, DbValue>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl DerefMut for DbRow {
+    fn deref_mut(&mut self) -> &mut IndexMap<String, DbValue> {
+        &mut self.map
+    }
+}
+
+impl DbRow {
+    pub fn new() -> Self {
+        DbRow {
+            map: IndexMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: String, value: DbValue) {
+        self.map.insert(key, value);
+    }
+
+    pub fn get(&self, key: &str) -> Option<DbValue> {
+        self.map.get(key).cloned()
+    }
+}
+
+impl IntoIterator for DbRow {
+    type Item = (String, DbValue);
+    type IntoIter = indexmap::map::IntoIter<String, DbValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl FromIterator<(String, DbValue)> for DbRow {
+    fn from_iter<I: IntoIterator<Item = (String, DbValue)>>(iter: I) -> Self {
+        DbRow {
+            map: iter.into_iter().collect(),
+        }
     }
 }
 

--- a/src/db_value.rs
+++ b/src/db_value.rs
@@ -6,15 +6,67 @@ use serde_json::{Map as JsonMap, json};
 use std::{
     fmt::Display,
     hash::{Hash, Hasher},
+    ops::{Deref, DerefMut},
 };
 
 pub type JsonValue = serde_json::Value;
 pub type JsonRow = JsonMap<String, JsonValue>;
-pub type DbRow = IndexMap<String, DbValue>;
 pub type StringRow = IndexMap<String, String>;
 pub type ColumnMap = IndexMap<String, String>;
 
-/// Value types for [query parameters](DbParams)
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+pub struct DbRow {
+    pub map: IndexMap<String, DbValue>,
+}
+
+impl Deref for DbRow {
+    type Target = IndexMap<String, DbValue>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl DerefMut for DbRow {
+    fn deref_mut(&mut self) -> &mut IndexMap<String, DbValue> {
+        &mut self.map
+    }
+}
+
+impl DbRow {
+    pub fn new() -> Self {
+        DbRow {
+            map: IndexMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: String, value: DbValue) {
+        self.map.insert(key, value);
+    }
+
+    pub fn get(&self, key: &str) -> Option<DbValue> {
+        self.map.get(key).cloned()
+    }
+}
+
+impl IntoIterator for DbRow {
+    type Item = (String, DbValue);
+    type IntoIter = indexmap::map::IntoIter<String, DbValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl FromIterator<(String, DbValue)> for DbRow {
+    fn from_iter<I: IntoIterator<Item = (String, DbValue)>>(iter: I) -> Self {
+        DbRow {
+            map: iter.into_iter().collect(),
+        }
+    }
+}
+
+/// Database Value types
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum DbValue {
     /// Represents a NULL value. Can be used with any column type.
@@ -905,6 +957,33 @@ macro_rules! params {
         [$($value.into_db_value()),*]
 
     }};
+}
+
+/// Converts a key value pair into a [DbRow]. The syntax of this macro is identical to
+/// [indexmap]. For example: db_row! { key1 -> value1, key2 -> value2, ... }
+/// The code for this function is adapted from the code for indexmap! (see
+/// <https://docs.rs/indexmap/latest/src/indexmap/macros.rs.html#59-73>
+#[macro_export]
+macro_rules! db_row {
+    ($($key:expr => $value:expr,)+) => {
+        DbRow {
+            map: indexmap::indexmap!($($key => $value),+)
+        }
+    };
+    ($($key:expr => $value:expr),*) => {
+        DbRow {
+            map: {
+                // Note: `stringify!($key)` is just here to consume the repetition,
+                // but we throw away that string literal during constant evaluation.
+                const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
+                let mut map = indexmap::IndexMap::with_capacity(CAP);
+                $(
+                    map.insert($key, $value);
+                )*
+                    map
+            }
+        }
+    };
 }
 
 #[cfg(test)]

--- a/src/db_value.rs
+++ b/src/db_value.rs
@@ -1,5 +1,5 @@
 use crate::core::DbError;
-use indexmap::IndexMap;
+use indexmap::{self, IndexMap};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, json};
@@ -764,6 +764,7 @@ impl<T: IntoDbValue> IntoDbParams for Vec<T> {
 
 /// A row of database values indexed by column name.
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(transparent)] // See https://serde.rs/container-attrs.html#transparent
 pub struct DbRow {
     pub map: IndexMap<String, DbValue>,
 }
@@ -985,6 +986,28 @@ macro_rules! db_row {
                 )*
                     map
             }
+        }
+    };
+}
+
+// TODO: Try this instead:
+/// Converts a set of pairs into a [DbRow]
+#[macro_export]
+macro_rules! db_row_new {
+    (@single $($x:tt)*) => (());
+    (@count $($rest:expr),*) => (<[()]>::len(&[$(indexmap::indexmap!(@single $rest)),*]));
+
+    ($($key:expr => $value:expr,)+) => {
+        indexmap::indexmap!($($key.to_string() => $value.into()),+)
+    };
+    ($($key:expr => $value:expr),*) => {
+        {
+            let cap = indexmap::indexmap!(@count $($key),*);
+            let mut map = indexmap::IndexMap::with_capacity(cap);
+            $(
+                let _ = map.insert($key.to_string(), $value.into());
+            )*
+                map
         }
     };
 }

--- a/src/db_value.rs
+++ b/src/db_value.rs
@@ -649,6 +649,12 @@ impl From<JsonValue> for DbValue {
     }
 }
 
+impl From<&JsonValue> for DbValue {
+    fn from(item: &JsonValue) -> Self {
+        item.into()
+    }
+}
+
 impl From<()> for DbValue {
     fn from(_: ()) -> Self {
         DbValue::Null
@@ -761,7 +767,7 @@ impl<T: IntoDbValue> IntoDbParams for Vec<T> {
 // Database rows
 
 /// A row of database values indexed by column name.
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(transparent)] // See https://serde.rs/container-attrs.html#transparent
 pub struct DbRow {
     pub map: IndexMap<String, DbValue>,

--- a/src/db_value.rs
+++ b/src/db_value.rs
@@ -47,6 +47,10 @@ impl DbValue {
         self.as_bool().is_some()
     }
 
+    pub fn is_i8(&self) -> bool {
+        self.as_i8().is_some()
+    }
+
     pub fn is_i16(&self) -> bool {
         self.as_i16().is_some()
     }
@@ -57,6 +61,10 @@ impl DbValue {
 
     pub fn is_i64(&self) -> bool {
         self.as_i64().is_some()
+    }
+
+    pub fn is_u8(&self) -> bool {
+        self.as_u8().is_some()
     }
 
     pub fn is_f32(&self) -> bool {
@@ -83,6 +91,10 @@ impl DbValue {
         self.try_into().ok()
     }
 
+    pub fn as_i8(&self) -> Option<i8> {
+        self.try_into().ok()
+    }
+
     pub fn as_i16(&self) -> Option<i16> {
         self.try_into().ok()
     }
@@ -92,6 +104,10 @@ impl DbValue {
     }
 
     pub fn as_i64(&self) -> Option<i64> {
+        self.try_into().ok()
+    }
+
+    pub fn as_u8(&self) -> Option<u8> {
         self.try_into().ok()
     }
 
@@ -317,6 +333,33 @@ impl TryInto<u16> for &DbValue {
     }
 }
 
+impl TryInto<u8> for DbValue {
+    type Error = DbError;
+
+    fn try_into(self) -> Result<u8, DbError> {
+        match self {
+            DbValue::SmallInteger(number) => {
+                Ok(u8::try_from(number).map_err(|err| DbError::InputError(err.to_string()))?)
+            }
+            DbValue::Integer(number) => {
+                Ok(u8::try_from(number).map_err(|err| DbError::InputError(err.to_string()))?)
+            }
+            DbValue::BigInteger(number) => {
+                Ok(u8::try_from(number).map_err(|err| DbError::InputError(err.to_string()))?)
+            }
+            _ => Err(DbError::InputError(format!("Not an integer: {self:?}"))),
+        }
+    }
+}
+
+impl TryInto<u8> for &DbValue {
+    type Error = DbError;
+
+    fn try_into(self) -> Result<u8, DbError> {
+        self.clone().try_into()
+    }
+}
+
 impl TryInto<i64> for DbValue {
     type Error = DbError;
 
@@ -394,6 +437,33 @@ impl TryInto<i16> for &DbValue {
     type Error = DbError;
 
     fn try_into(self) -> Result<i16, DbError> {
+        self.clone().try_into()
+    }
+}
+
+impl TryInto<i8> for DbValue {
+    type Error = DbError;
+
+    fn try_into(self) -> Result<i8, DbError> {
+        match self {
+            DbValue::SmallInteger(number) => {
+                Ok(i8::try_from(number).map_err(|err| DbError::InputError(err.to_string()))?)
+            }
+            DbValue::Integer(number) => {
+                Ok(i8::try_from(number).map_err(|err| DbError::InputError(err.to_string()))?)
+            }
+            DbValue::BigInteger(number) => {
+                Ok(i8::try_from(number).map_err(|err| DbError::InputError(err.to_string()))?)
+            }
+            _ => Err(DbError::InputError(format!("Not an integer: {self:?}"))),
+        }
+    }
+}
+
+impl TryInto<i8> for &DbValue {
+    type Error = DbError;
+
+    fn try_into(self) -> Result<i8, DbError> {
         self.clone().try_into()
     }
 }
@@ -534,6 +604,12 @@ impl From<&String> for DbValue {
     }
 }
 
+impl From<i8> for DbValue {
+    fn from(item: i8) -> Self {
+        DbValue::SmallInteger(item.into())
+    }
+}
+
 impl From<i16> for DbValue {
     fn from(item: i16) -> Self {
         DbValue::SmallInteger(item)
@@ -549,6 +625,12 @@ impl From<i32> for DbValue {
 impl From<i64> for DbValue {
     fn from(item: i64) -> Self {
         DbValue::BigInteger(item)
+    }
+}
+
+impl From<u8> for DbValue {
+    fn from(item: u8) -> Self {
+        DbValue::SmallInteger(item.into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db_kind;
 pub mod db_value;
 pub mod memory;
 pub mod parse;
+pub mod serde;
 pub mod shared;
 
 #[cfg(feature = "rusqlite")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod libsql;
 
 // Macro definitions
 
-/// Converts a list of assorted types implementing [IntoDbValue] into [DbParams]
+/// Converts a list of assorted types implementing [db_value::IntoDbValue] into [db_value::DbParams]
 #[macro_export]
 macro_rules! params {
     () => {
@@ -31,7 +31,7 @@ macro_rules! params {
     }};
 }
 
-/// Converts a key value pair into a [DbRow]. The syntax of this macro is identical to
+/// Converts a key value pair into a [db_value::DbRow]. The syntax of this macro is identical to
 /// [indexmap]. For example: db_row! { key1 -> value1, key2 -> value2, ... }
 /// The code for this function is adapted from the code for indexmap! (see
 /// <https://docs.rs/indexmap/latest/src/indexmap/macros.rs.html#59-73>
@@ -59,7 +59,7 @@ macro_rules! db_row {
 }
 
 // TODO: Try this instead:
-/// Converts a set of pairs into a [DbRow]
+/// Converts a set of pairs into a [db_value::DbRow]
 #[macro_export]
 macro_rules! db_row_new {
     (@single $($x:tt)*) => (());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,14 @@ macro_rules! params {
     }};
 }
 
+
+// TODO: Remove this later.
 /// Converts a key value pair into a [db_value::DbRow]. The syntax of this macro is identical to
 /// [indexmap]. For example: db_row! { key1 -> value1, key2 -> value2, ... }
 /// The code for this function is adapted from the code for indexmap! (see
 /// <https://docs.rs/indexmap/latest/src/indexmap/macros.rs.html#59-73>
 #[macro_export]
-macro_rules! db_row {
+macro_rules! db_row_old {
     ($($key:expr => $value:expr,)+) => {
         $crate::db_value::DbRow {
             map: indexmap::indexmap!($($key => $value),+)
@@ -58,15 +60,20 @@ macro_rules! db_row {
     };
 }
 
-// TODO: Try this instead:
-/// Converts a set of pairs into a [db_value::DbRow]
+/// Converts a set of pairs into a [db_value::DbRow]. Note that all entries must end in a comma,
+/// even the final one. E.g.,
+/// db_row_new! {
+///   "table" => "data",
+/// };
 #[macro_export]
-macro_rules! db_row_new {
-    (@single $($x:tt)*) => (());
-    (@count $($rest:expr),*) => (<[()]>::len(&[$(indexmap::indexmap!(@single $rest)),*]));
+macro_rules! db_row {
+    // TODO: What are these two lines for? This macro (like the one above) seems to be working
+    // without them?
+    // (@single $($x:tt)*) => (());
+    // (@count $($rest:expr),*) => (<[()]>::len(&[$(indexmap::indexmap!(@single $rest)),*]));
 
     ($($key:expr => $value:expr,)+) => {
-        indexmap::indexmap!($($key.to_string() => $value.into()),+)
+        DbRow {map: indexmap::indexmap!($($key.to_string() => $value.into()),+) }
     };
     ($($key:expr => $value:expr),*) => {
         {
@@ -75,7 +82,47 @@ macro_rules! db_row_new {
             $(
                 let _ = map.insert($key.to_string(), $value.into());
             )*
-                map
+                DbRow { map }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db_value::{DbRow, DbValue};
+
+    #[test]
+    fn test_macros() {
+        let params = params![1_i32, "foo", 1.1_f64];
+        assert_eq!(
+            params,
+            [
+                DbValue::Integer(1),
+                DbValue::Text("foo".to_string()),
+                DbValue::BigReal(1.1_f64)
+            ]
+        );
+
+        let mut expected_db_row = DbRow::new();
+        expected_db_row
+            .map
+            .insert("foo".to_string(), DbValue::Boolean(true));
+        expected_db_row
+            .map
+            .insert("bar".to_string(), DbValue::BigReal(1_f64));
+
+
+        assert_eq!(
+            expected_db_row,
+            db_row_old! {
+                "foo".into() => DbValue::from(true),
+                "bar".into() => DbValue::from(1_f64),
+            }
+        );
+
+        assert_eq!(
+            expected_db_row,
+            db_row! { "foo" => true, "bar" => 1_f64,}
+        );
+    }
 }

--- a/src/libsql.rs
+++ b/src/libsql.rs
@@ -307,8 +307,7 @@ impl DbQuery for LibSQLPool {
 mod tests {
     use super::*;
 
-    use crate::params;
-    use indexmap::indexmap as db_row;
+    use crate::{db_row, params};
 
     #[tokio::test]
     async fn test_aliases_and_builtin_functions() {

--- a/src/libsql.rs
+++ b/src/libsql.rs
@@ -340,7 +340,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             rows,
-            [db_row! {"MAX(int_value)".into() => DbValue::from(1_i64)}]
+            [db_row! {
+                "MAX(int_value)" => 1_i64,
+            }]
         );
 
         // Test alias:
@@ -353,7 +355,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             rows,
-            [db_row! {"bool_value_alias".into() => DbValue::from(1_i64)}]
+            [db_row! {
+                "bool_value_alias" => 1_i64,
+            }]
         );
 
         // Test aggregate with alias:
@@ -367,7 +371,9 @@ mod tests {
         // Note that the alias is not shown in the results:
         assert_eq!(
             rows,
-            [db_row! {"max_int_value".into() => DbValue::from(1_i64)}]
+            [db_row! {
+                "max_int_value" => 1_i64,
+            }]
         );
 
         // Test non-aggregate function:
@@ -378,10 +384,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(
-            rows,
-            [db_row! {"CAST(int_value AS TEXT)".into() => DbValue::from("1")}]
-        );
+        assert_eq!(rows, [db_row! {"CAST(int_value AS TEXT)" => "1",}]);
 
         // Test non-aggregate function with alias:
         let rows: Vec<DbRow> = pool
@@ -391,10 +394,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(
-            rows,
-            [db_row! {"int_value_cast".into() => DbValue::from("1")}]
-        );
+        assert_eq!(rows, [db_row! {"int_value_cast" => "1",}]);
 
         // Test functions over booleans:
         let rows: Vec<DbRow> = pool
@@ -410,10 +410,7 @@ mod tests {
         //          name and argument types. You might need to add explicit type casts.
         // So, perhaps, this is tu quoque an argument that the behaviour below is acceptable for
         // sqlite.
-        assert_eq!(
-            rows,
-            [db_row! {"MAX(bool_value)".into() => DbValue::from(1_i64)}]
-        );
+        assert_eq!(rows, [db_row! {"MAX(bool_value)" => 1_i64,}]);
     }
 
     /// This test is resource intensive and therefore ignored by default. It verifies that

--- a/src/rusqlite.rs
+++ b/src/rusqlite.rs
@@ -414,8 +414,7 @@ impl DbQuery for RusqlitePool {
 mod tests {
     use super::*;
 
-    use crate::params;
-    use indexmap::indexmap as db_row;
+    use crate::{db_row, params};
 
     #[tokio::test]
     async fn test_aliases_and_builtin_functions() {

--- a/src/rusqlite.rs
+++ b/src/rusqlite.rs
@@ -447,7 +447,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             rows,
-            [db_row! {"MAX(int_value)".into() => DbValue::from(1_i64)}]
+            [db_row! {
+                "MAX(int_value)" => 1_i64,
+            }]
         );
 
         // Test alias:
@@ -458,10 +460,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(
-            rows,
-            [db_row! {"bool_value_alias".into() => DbValue::from(1_i64)}]
-        );
+        assert_eq!(rows, [db_row! {"bool_value_alias" => 1_i64,}]);
 
         // Test aggregate with alias:
         let rows: Vec<DbRow> = pool
@@ -472,10 +471,7 @@ mod tests {
             .await
             .unwrap();
         // Note that the alias is not shown in the results:
-        assert_eq!(
-            rows,
-            [db_row! {"max_int_value".into() => DbValue::from(1_i64)}]
-        );
+        assert_eq!(rows, [db_row! {"max_int_value" => 1_i64,}]);
 
         // Test non-aggregate function:
         let rows: Vec<DbRow> = pool
@@ -487,7 +483,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             rows,
-            [db_row! {"CAST(int_value AS TEXT)".into() => DbValue::from("1")}]
+            [db_row! {
+                "CAST(int_value AS TEXT)" => "1",
+            }]
         );
 
         // Test non-aggregate function with alias:
@@ -500,7 +498,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             rows,
-            [db_row! {"int_value_cast".into() => DbValue::from("1")}]
+            [db_row! {
+                "int_value_cast" => "1",
+            }]
         );
 
         // Test functions over booleans:
@@ -519,7 +519,9 @@ mod tests {
         // sqlite.
         assert_eq!(
             rows,
-            [db_row! {"MAX(bool_value)".into() => DbValue::from(1_i64)}]
+            [db_row! {
+                "MAX(bool_value)" => 1_i64,
+            }]
         );
     }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,8 +1,12 @@
-use crate::core::DbError;
+use crate::{
+    core::DbError,
+    db_value::{DbRow, DbValue, JsonValue},
+};
 use serde::{
     Serialize,
     ser::{self, SerializeSeq as _},
 };
+use serde_json::from_str;
 
 // TODO: Most of the comments and docstrings below were copied (initially) verbatim from
 // https://serde.rs/impl-serializer.html. After we adapt that template to our use case these
@@ -10,24 +14,71 @@ use serde::{
 
 /// Used for serialization / deserialization of a [DbRow] to/from a struct
 pub struct Serializer {
-    output: String,
+    output_old_remove_me: String,
+    _output_new_not_used_yet: DbRow,
 }
 
 // By convention, the public API of a Serde serializer is one or more `to_abc`
 // functions such as `to_string`, `to_bytes`, or `to_writer` depending on what
 // Rust types the serializer is able to produce as output.
 //
-// This basic serializer supports only `to_string`.
 
 pub fn to_string<T>(value: &T) -> Result<String, DbError>
 where
     T: Serialize,
 {
     let mut serializer = Serializer {
-        output: String::new(),
+        output_old_remove_me: String::new(),
+        _output_new_not_used_yet: DbRow::new(),
     };
     value.serialize(&mut serializer)?;
-    Ok(serializer.output)
+    Ok(serializer.output_old_remove_me)
+}
+
+pub fn to_db_row<T>(value: &T) -> Result<DbRow, DbError>
+where
+    T: Serialize,
+{
+    // TODO: This is a very inefficient way of serializing a struct to a DbRow. We should
+    // eliminate the dependency on serde_json and ideally serialize directly to a DbRow
+    // rather than first to a string. We might be able to use "type OK = TYPE" (see below)
+    // to help with this.
+
+    let value_string = to_string(value)?;
+    println!("VALUE STRING: {value_string}");
+
+    let mut db_row = DbRow::new();
+    // TODO: Remove unwrap:
+    let json_row = from_str::<JsonValue>(&value_string).unwrap();
+    let json_row = json_row.as_object().unwrap();
+    for (column, value) in json_row.iter() {
+        println!("VALUE: {value:?}");
+        match value.as_object() {
+            Some(value) => {
+                // TODO: Remove assert
+                assert_eq!(value.len(), 1);
+                let value = value.iter().collect::<Vec<_>>()[0];
+                let value_type = value.0;
+                let value_value = DbValue::from(value.1.clone());
+                // TODO: Implement DbValue::from_str() so that we can match on the actual enums
+                // instead of on strings.
+                match value_type.to_lowercase().as_str() {
+                    "null" => db_row.insert(column.to_string(), DbValue::Null),
+                    "boolean" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    "smallinteger" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    "integer" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    "biginteger" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    "real" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    "bigreal" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    "numeric" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    "text" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    _ => panic!(),
+                }
+            }
+            None => db_row.insert(column.to_string(), DbValue::from(value.clone())),
+        }
+    }
+    Ok(db_row)
 }
 
 impl<'a> ser::Serializer for &'a mut Serializer {
@@ -59,7 +110,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     // into the output string.
 
     fn serialize_bool(self, value: bool) -> Result<(), Self::Error> {
-        self.output += match value {
+        self.output_old_remove_me += match value {
             true => "true",
             false => "false",
         };
@@ -86,7 +137,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     // Not particularly efficient but this is example code anyway. A more
     // performant approach would be to use the `itoa` crate.
     fn serialize_i64(self, value: i64) -> Result<(), Self::Error> {
-        self.output += &value.to_string();
+        self.output_old_remove_me += &value.to_string();
         Ok(())
     }
 
@@ -103,7 +154,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_u64(self, value: u64) -> Result<(), Self::Error> {
-        self.output += &value.to_string();
+        self.output_old_remove_me += &value.to_string();
         Ok(())
     }
 
@@ -112,7 +163,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_f64(self, value: f64) -> Result<(), Self::Error> {
-        self.output += &value.to_string();
+        self.output_old_remove_me += &value.to_string();
         Ok(())
     }
 
@@ -126,9 +177,9 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     // get the idea. For example it would emit invalid JSON if the input string
     // contains a '"' character.
     fn serialize_str(self, value: &str) -> Result<(), Self::Error> {
-        self.output += "\"";
-        self.output += value;
-        self.output += "\"";
+        self.output_old_remove_me += "\"";
+        self.output_old_remove_me += value;
+        self.output_old_remove_me += "\"";
         Ok(())
     }
 
@@ -163,7 +214,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     // In Serde, unit means an anonymous value containing no data. Map this to
     // JSON as `null`.
     fn serialize_unit(self) -> Result<(), Self::Error> {
-        self.output += "null";
+        self.output_old_remove_me += "null";
         Ok(())
     }
 
@@ -211,11 +262,11 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        self.output += "{";
+        self.output_old_remove_me += "{";
         variant.serialize(&mut *self)?;
-        self.output += ":";
+        self.output_old_remove_me += ":";
         value.serialize(&mut *self)?;
-        self.output += "}";
+        self.output_old_remove_me += "}";
         Ok(())
     }
 
@@ -230,7 +281,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     // explicitly in the serialized form. Some serializers may only be able to
     // support sequences for which the length is known up front.
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        self.output += "[";
+        self.output_old_remove_me += "[";
         Ok(self)
     }
 
@@ -260,15 +311,15 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         variant: &str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        self.output += "{";
+        self.output_old_remove_me += "{";
         variant.serialize(&mut *self)?;
-        self.output += ":[";
+        self.output_old_remove_me += ":[";
         Ok(self)
     }
 
     // Maps are represented in JSON as `{ K: V, K: V, ... }`.
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        self.output += "{";
+        self.output_old_remove_me += "{";
         Ok(self)
     }
 
@@ -294,9 +345,9 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         variant: &str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        self.output += "{";
+        self.output_old_remove_me += "{";
         variant.serialize(&mut *self)?;
-        self.output += ":{";
+        self.output_old_remove_me += ":{";
         Ok(self)
     }
 }
@@ -320,15 +371,15 @@ impl<'a> ser::SerializeSeq for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output.ends_with('[') {
-            self.output += ",";
+        if !self.output_old_remove_me.ends_with('[') {
+            self.output_old_remove_me += ",";
         }
         value.serialize(&mut **self)
     }
 
     // Close the sequence.
     fn end(self) -> Result<(), Self::Error> {
-        self.output += "]";
+        self.output_old_remove_me += "]";
         Ok(())
     }
 }
@@ -342,14 +393,14 @@ impl<'a> ser::SerializeTuple for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output.ends_with('[') {
-            self.output += ",";
+        if !self.output_old_remove_me.ends_with('[') {
+            self.output_old_remove_me += ",";
         }
         value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output += "]";
+        self.output_old_remove_me += "]";
         Ok(())
     }
 }
@@ -363,14 +414,14 @@ impl<'a> ser::SerializeTupleStruct for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output.ends_with('[') {
-            self.output += ",";
+        if !self.output_old_remove_me.ends_with('[') {
+            self.output_old_remove_me += ",";
         }
         value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output += "]";
+        self.output_old_remove_me += "]";
         Ok(())
     }
 }
@@ -378,9 +429,9 @@ impl<'a> ser::SerializeTupleStruct for &'a mut Serializer {
 // Tuple variants are a little different. Refer back to the
 // `serialize_tuple_variant` method above:
 //
-//    self.output += "{";
+//    self.output_old_remove_me += "{";
 //    variant.serialize(&mut *self)?;
-//    self.output += ":[";
+//    self.output_old_remove_me += ":[";
 //
 // So the `end` method in this impl is responsible for closing both the `]` and
 // the `}`.
@@ -392,14 +443,14 @@ impl<'a> ser::SerializeTupleVariant for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output.ends_with('[') {
-            self.output += ",";
+        if !self.output_old_remove_me.ends_with('[') {
+            self.output_old_remove_me += ",";
         }
         value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output += "]}";
+        self.output_old_remove_me += "]}";
         Ok(())
     }
 }
@@ -428,8 +479,8 @@ impl<'a> ser::SerializeMap for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output.ends_with('{') {
-            self.output += ",";
+        if !self.output_old_remove_me.ends_with('{') {
+            self.output_old_remove_me += ",";
         }
         key.serialize(&mut **self)
     }
@@ -441,12 +492,12 @@ impl<'a> ser::SerializeMap for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        self.output += ":";
+        self.output_old_remove_me += ":";
         value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output += "}";
+        self.output_old_remove_me += "}";
         Ok(())
     }
 }
@@ -461,16 +512,16 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output.ends_with('{') {
-            self.output += ",";
+        if !self.output_old_remove_me.ends_with('{') {
+            self.output_old_remove_me += ",";
         }
         key.serialize(&mut **self)?;
-        self.output += ":";
+        self.output_old_remove_me += ":";
         value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output += "}";
+        self.output_old_remove_me += "}";
         Ok(())
     }
 }
@@ -485,16 +536,16 @@ impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output.ends_with('{') {
-            self.output += ",";
+        if !self.output_old_remove_me.ends_with('{') {
+            self.output_old_remove_me += ",";
         }
         key.serialize(&mut **self)?;
-        self.output += ":";
+        self.output_old_remove_me += ":";
         value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output += "}}";
+        self.output_old_remove_me += "}}";
         Ok(())
     }
 }
@@ -507,49 +558,27 @@ mod tests {
     #[test]
     fn test_serde_struct() {
         #[derive(Serialize)]
-        struct Test {
-            int: u32,
-            seq: Vec<&'static str>,
+        struct Foo {
+            bar: u32,
+            xyzzy: String,
         }
 
-        let test = Test {
-            int: 1,
-            seq: vec!["a", "b"],
+        let test = Foo {
+            bar: 1,
+            xyzzy: "test".to_string(),
         };
-        let expected = r#"{"int":1,"seq":["a","b"]}"#;
-        assert_eq!(to_string(&test).unwrap(), expected);
+        let expected_string = r#"{"bar":1,"xyzzy":"test"}"#;
+        assert_eq!(to_string(&test).unwrap(), expected_string);
 
-        // DbRow tests begin here:
+        let expected_db_row = db_row! {
+            "bar".into() => DbValue::from(1_u32),
+            "xyzzy".into() => DbValue::from("test"),
+        };
+        assert_eq!(to_db_row(&test).unwrap(), expected_db_row);
 
         let db_row = db_row! {"value".into() => DbValue::from("foo")};
-        let expected = r#"{"value":{"Text":"foo"}}"#;
-        assert_eq!(to_string(&db_row).unwrap(), expected);
-    }
-
-    #[test]
-    fn test_serde_enum() {
-        #[derive(Serialize)]
-        enum E {
-            Unit,
-            Newtype(u32),
-            Tuple(u32, u32),
-            Struct { a: u32 },
-        }
-
-        let u = E::Unit;
-        let expected = r#""Unit""#;
-        assert_eq!(to_string(&u).unwrap(), expected);
-
-        let n = E::Newtype(1);
-        let expected = r#"{"Newtype":1}"#;
-        assert_eq!(to_string(&n).unwrap(), expected);
-
-        let t = E::Tuple(1, 2);
-        let expected = r#"{"Tuple":[1,2]}"#;
-        assert_eq!(to_string(&t).unwrap(), expected);
-
-        let s = E::Struct { a: 1 };
-        let expected = r#"{"Struct":{"a":1}}"#;
-        assert_eq!(to_string(&s).unwrap(), expected);
+        let expected_string = r#"{"value":{"Text":"foo"}}"#;
+        assert_eq!(to_string(&db_row).unwrap(), expected_string);
+        assert_eq!(to_db_row(&db_row).unwrap(), db_row);
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,12 +1,16 @@
 use crate::{
     core::DbError,
-    db_value::{DbRow, DbValue, JsonValue},
+    db_value::{DbRow, DbValue, JsonRow, JsonValue},
 };
 use serde::{
-    Serialize,
+    Deserialize, Serialize,
+    de::{
+        self, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, VariantAccess,
+        Visitor,
+    },
     ser::{self, SerializeSeq as _},
 };
-use serde_json::from_str;
+use std::ops::{AddAssign, MulAssign, Neg};
 
 // TODO: Most of the comments and docstrings below were copied (initially) verbatim from
 // https://serde.rs/impl-serializer.html. After we adapt that template to our use case these
@@ -39,29 +43,25 @@ pub fn to_db_row<T>(value: &T) -> Result<DbRow, DbError>
 where
     T: Serialize,
 {
-    // TODO: This is a very inefficient way of serializing a struct to a DbRow. We should
-    // eliminate the dependency on serde_json and ideally serialize directly to a DbRow
+    // TODO: This is a very inefficient way of serializing a struct to a DbRow, but it works.
+    // We need to eliminate the dependency on serde_json and serialize directly to a DbRow
     // rather than first to a string. We might be able to use "type OK = TYPE" (see below)
     // to help with this.
 
     let value_string = to_string(value)?;
-    println!("VALUE STRING: {value_string}");
+    //println!("VALUE STRING: {value_string}");
 
     let mut db_row = DbRow::new();
-    // TODO: Remove unwrap:
-    let json_row = from_str::<JsonValue>(&value_string).unwrap();
+    let json_row = serde_json::from_str::<JsonValue>(&value_string).unwrap();
     let json_row = json_row.as_object().unwrap();
     for (column, value) in json_row.iter() {
-        println!("VALUE: {value:?}");
+        //println!("VALUE: {value:?}");
         match value.as_object() {
             Some(value) => {
-                // TODO: Remove assert
                 assert_eq!(value.len(), 1);
                 let value = value.iter().collect::<Vec<_>>()[0];
                 let value_type = value.0;
                 let value_value = DbValue::from(value.1.clone());
-                // TODO: Implement DbValue::from_str() so that we can match on the actual enums
-                // instead of on strings.
                 match value_type.to_lowercase().as_str() {
                     "null" => db_row.insert(column.to_string(), DbValue::Null),
                     "boolean" => db_row.insert(column.to_string(), DbValue::from(value_value)),
@@ -550,6 +550,750 @@ impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
     }
 }
 
+// Deserialization
+
+#[derive(Debug)]
+pub struct Deserializer<'de> {
+    // This string starts with the input data and characters are truncated off
+    // the beginning as data is parsed.
+    input: &'de str,
+    _input_new: DbRow,
+}
+
+impl<'de> Deserializer<'de> {
+    // By convention, `Deserializer` constructors are named like `from_xyz`.
+    // That way basic use cases are satisfied by something like
+    // `serde_json::from_str(...)` while advanced use cases that require a
+    // deserializer can make one with `serde_json::Deserializer::from_str(...)`.
+    // // pub fn from_str(input: &'de str) -> Self {
+    // //     Deserializer {
+    // //         input,
+    // //         _input_new: DbRow::new(),
+    // //     }
+    // // }
+}
+
+// By convention, the public API of a Serde deserializer is one or more
+// `from_xyz` methods such as `from_str`, `from_bytes`, or `from_reader`
+// depending on what Rust types the deserializer is able to consume as input.
+
+// // This basic deserializer supports only `from_str`.
+// pub fn from_str<'a, T>(s: &'a str) -> Result<T, DbError>
+// where
+//     T: Deserialize<'a>,
+// {
+//     let mut deserializer = Deserializer::from_str(s);
+//     let t = T::deserialize(&mut deserializer)?;
+//     if deserializer.input.is_empty() {
+//         Ok(t)
+//     } else {
+//         Err(DbError::SerdeError(
+//             "Deserialization error: TrailingCharacters".to_string(),
+//         ))
+//     }
+// }
+
+pub fn from_db_row<T>(db_row: &DbRow) -> Result<T, DbError>
+where
+    T: for<'a> Deserialize<'a>,
+{
+    // TODO: This is a very inefficient way of deserializing a DbRow to a struct, but it works.
+    // We need to eliminate the dependency on serde_json and deserialize the DbRow directly to the
+    // struct rather than first to a String.
+
+    let string_row = to_string(db_row).unwrap();
+    let value: JsonValue = serde_json::from_str(&string_row).unwrap();
+    let json_row: JsonRow = value.as_object().unwrap().clone();
+
+    let mut flat_json_row = JsonRow::new();
+    for (column, value) in json_row.iter() {
+        //println!("VALUE: {value:?}");
+        match value.as_object() {
+            Some(value) => {
+                assert_eq!(value.len(), 1);
+                let value = value.iter().collect::<Vec<_>>()[0];
+                let value_type = value.0;
+                let value_value = JsonValue::from(value.1.clone());
+                match value_type.to_lowercase().as_str() {
+                    "null" => flat_json_row.insert(column.to_string(), JsonValue::Null),
+                    "boolean" => {
+                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
+                    }
+                    "smallinteger" => {
+                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
+                    }
+                    "integer" => {
+                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
+                    }
+                    "biginteger" => {
+                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
+                    }
+                    "real" => {
+                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
+                    }
+                    "bigreal" => {
+                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
+                    }
+                    "numeric" => {
+                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
+                    }
+                    "text" => {
+                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
+                    }
+                    _ => panic!(),
+                }
+            }
+            None => flat_json_row.insert(column.to_string(), JsonValue::from(value.clone())),
+        };
+    }
+    let flat_string_row = format!("{}", serde_json::json!(flat_json_row));
+    let t_struct: T = serde_json::from_str(&flat_string_row).unwrap();
+    Ok(t_struct)
+}
+
+// SERDE IS NOT A PARSING LIBRARY. This impl block defines a few basic parsing
+// functions from scratch. More complicated formats may wish to use a dedicated
+// parsing library to help implement their Serde deserializer.
+impl<'de> Deserializer<'de> {
+    // Look at the first character in the input without consuming it.
+    fn peek_char(&mut self) -> Result<char, DbError> {
+        self.input.chars().next().ok_or(DbError::SerdeError(
+            "Deserialization error: EoF".to_string(),
+        ))
+    }
+
+    // Consume the first character in the input.
+    fn next_char(&mut self) -> Result<char, DbError> {
+        let ch = self.peek_char()?;
+        self.input = &self.input[ch.len_utf8()..];
+        Ok(ch)
+    }
+
+    // Parse the JSON identifier `true` or `false`.
+    fn parse_bool(&mut self) -> Result<bool, DbError> {
+        if self.input.starts_with("true") {
+            self.input = &self.input["true".len()..];
+            Ok(true)
+        } else if self.input.starts_with("false") {
+            self.input = &self.input["false".len()..];
+            Ok(false)
+        } else {
+            Err(DbError::SerdeError(
+                "Deserialization error: ExpectedBoolean".to_string(),
+            ))
+        }
+    }
+
+    // Parse a group of decimal digits as an unsigned integer of type T.
+    //
+    // This implementation is a bit too lenient, for example `001` is not
+    // allowed in JSON. Also the various arithmetic operations can overflow and
+    // panic or return bogus data. But it is good enough for example code!
+    fn parse_unsigned<T>(&mut self) -> Result<T, DbError>
+    where
+        T: AddAssign<T> + MulAssign<T> + From<u8>,
+    {
+        let mut int = match self.next_char()? {
+            ch @ '0'..='9' => T::from(ch as u8 - b'0'),
+            _ => {
+                return Err(DbError::SerdeError(
+                    "Deserialization error: ExpectedInteger".to_string(),
+                ));
+            }
+        };
+        loop {
+            match self.input.chars().next() {
+                Some(ch @ '0'..='9') => {
+                    self.input = &self.input[1..];
+                    int *= T::from(10);
+                    int += T::from(ch as u8 - b'0');
+                }
+                _ => {
+                    return Ok(int);
+                }
+            }
+        }
+    }
+
+    // Parse a possible minus sign followed by a group of decimal digits as a
+    // signed integer of type T.
+    fn parse_signed<T>(&mut self) -> Result<T, DbError>
+    where
+        T: Neg<Output = T> + AddAssign<T> + MulAssign<T> + From<i8>,
+    {
+        // Optional minus sign, delegate to `parse_unsigned`, negate if negative.
+        unimplemented!()
+    }
+
+    // Parse a string until the next '"' character.
+    //
+    // Makes no attempt to handle escape sequences. What did you expect? This is
+    // example code!
+    fn parse_string(&mut self) -> Result<&'de str, DbError> {
+        if self.next_char()? != '"' {
+            return Err(DbError::SerdeError(
+                "Deserialization error: ExpectedString".to_string(),
+            ));
+        }
+        match self.input.find('"') {
+            Some(len) => {
+                let s = &self.input[..len];
+                self.input = &self.input[len + 1..];
+                Ok(s)
+            }
+            None => Err(DbError::SerdeError(
+                "Deserialization error: EoF".to_string(),
+            )),
+        }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
+    type Error = DbError;
+
+    // Look at the input data to decide what Serde data model type to
+    // deserialize as. Not all data formats are able to support this operation.
+    // Formats that support `deserialize_any` are known as self-describing.
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.peek_char()? {
+            'n' => self.deserialize_unit(visitor),
+            't' | 'f' => self.deserialize_bool(visitor),
+            '"' => self.deserialize_str(visitor),
+            '0'..='9' => self.deserialize_u64(visitor),
+            '-' => self.deserialize_i64(visitor),
+            '[' => self.deserialize_seq(visitor),
+            '{' => {
+                println!("IN DESERIALIZE_ANY");
+                self.deserialize_map(visitor)
+            }
+            _ => Err(DbError::SerdeError(
+                "Deserialization error: ErrorSyntax".to_string(),
+            )),
+        }
+    }
+
+    // Uses the `parse_bool` parsing function defined above to read the JSON
+    // identifier `true` or `false` from the input.
+    //
+    // Parsing refers to looking at the input and deciding that it contains the
+    // JSON value `true` or `false`.
+    //
+    // Deserialization refers to mapping that JSON value into Serde's data
+    // model by invoking one of the `Visitor` methods. In the case of JSON and
+    // bool that mapping is straightforward so the distinction may seem silly,
+    // but in other cases Deserializers sometimes perform non-obvious mappings.
+    // For example the TOML format has a Datetime type and Serde's data model
+    // does not. In the `toml` crate, a Datetime in the input is deserialized by
+    // mapping it to a Serde data model "struct" type with a special name and a
+    // single field containing the Datetime represented as a string.
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_bool(self.parse_bool()?)
+    }
+
+    // The `parse_signed` function is generic over the integer type `T` so here
+    // it is invoked with `T=i8`. The next 8 methods are similar.
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i8(self.parse_signed()?)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i16(self.parse_signed()?)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i32(self.parse_signed()?)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i64(self.parse_signed()?)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u8(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u16(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u32(self.parse_unsigned()?)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(self.parse_unsigned()?)
+    }
+
+    // Float parsing is stupidly hard.
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    // Float parsing is stupidly hard.
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    // The `Serializer` implementation on the previous page serialized chars as
+    // single-character strings so handle that representation here.
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // Parse a string, check that it is one character, call `visit_char`.
+        unimplemented!()
+    }
+
+    // Refer to the "Understanding deserializer lifetimes" page for information
+    // about the three deserialization flavors of strings in Serde.
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.parse_string()?)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    // The `Serializer` implementation on the previous page serialized byte
+    // arrays as JSON arrays of bytes. Handle that representation here.
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    // An absent optional is represented as the JSON `null` and a present
+    // optional is represented as just the contained value.
+    //
+    // As commented in `Serializer` implementation, this is a lossy
+    // representation. For example the values `Some(())` and `None` both
+    // serialize as just `null`. Unfortunately this is typically what people
+    // expect when working with JSON. Other formats are encouraged to behave
+    // more intelligently if possible.
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        if self.input.starts_with("null") {
+            self.input = &self.input["null".len()..];
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    // In Serde, unit means an anonymous value containing no data.
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        if self.input.starts_with("null") {
+            self.input = &self.input["null".len()..];
+            visitor.visit_unit()
+        } else {
+            Err(DbError::SerdeError(
+                "Deserialization error: ExpectedNull".to_string(),
+            ))
+        }
+    }
+
+    // Unit struct means a named value containing no data.
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    // As is done here, serializers are encouraged to treat newtype structs as
+    // insignificant wrappers around the data they contain. That means not
+    // parsing anything other than the contained value.
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    // Deserialization of compound types like sequences and maps happens by
+    // passing the visitor an "Access" object that gives it the ability to
+    // iterate through the data contained in the sequence.
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // Parse the opening bracket of the sequence.
+        if self.next_char()? == '[' {
+            // Give the visitor access to each element of the sequence.
+            let value = visitor.visit_seq(CommaSeparated::new(self))?;
+            // Parse the closing bracket of the sequence.
+            if self.next_char()? == ']' {
+                Ok(value)
+            } else {
+                Err(DbError::SerdeError(
+                    "Deserialization error: ExpectedArrayEnd".to_string(),
+                ))
+            }
+        } else {
+            Err(DbError::SerdeError(
+                "Deserialization error: ExpectedArray".to_string(),
+            ))
+        }
+    }
+
+    // Tuples look just like sequences in JSON. Some formats may be able to
+    // represent tuples more efficiently.
+    //
+    // As indicated by the length parameter, the `Deserialize` implementation
+    // for a tuple in the Serde data model is required to know the length of the
+    // tuple before even looking at the input data.
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    // Tuple structs look just like sequences in JSON.
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    // Much like `deserialize_seq` but calls the visitors `visit_map` method
+    // with a `MapAccess` implementation, rather than the visitor's `visit_seq`
+    // method with a `SeqAccess` implementation.
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // Parse the opening brace of the map.
+        if self.next_char()? == '{' {
+            // Give the visitor access to each entry of the map.
+            let value = visitor.visit_map(CommaSeparated::new(self))?;
+            // Parse the closing brace of the map.
+            if self.next_char()? == '}' {
+                Ok(value)
+            } else {
+                Err(DbError::SerdeError(
+                    "Deserialization error: ExpectedMapEnd".to_string(),
+                ))
+            }
+        } else {
+            Err(DbError::SerdeError(
+                "Deserialization error: ExpectedMap".to_string(),
+            ))
+        }
+    }
+
+    // Structs look just like maps in JSON.
+    //
+    // Notice the `fields` parameter - a "struct" in the Serde data model means
+    // that the `Deserialize` implementation is required to know what the fields
+    // are before even looking at the input data. Any key-value pairing in which
+    // the fields cannot be known ahead of time is probably a map.
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        println!("IN DESERIALIZE_STRUCT");
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        if self.peek_char()? == '"' {
+            // Visit a unit variant.
+            visitor.visit_enum(self.parse_string()?.into_deserializer())
+        } else if self.next_char()? == '{' {
+            // Visit a newtype variant, tuple variant, or struct variant.
+            let value = visitor.visit_enum(Enum::new(self))?;
+            // Parse the matching close brace.
+            if self.next_char()? == '}' {
+                Ok(value)
+            } else {
+                Err(DbError::SerdeError(
+                    "Deserialization error: ExpectedMapEnd".to_string(),
+                ))
+            }
+        } else {
+            Err(DbError::SerdeError(
+                "Deserialization error: ExpectedMap".to_string(),
+            ))
+        }
+    }
+
+    // An identifier in Serde is the type that identifies a field of a struct or
+    // the variant of an enum. In JSON, struct fields and enum variants are
+    // represented as strings. In other formats they may be represented as
+    // numeric indices.
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    // Like `deserialize_any` but indicates to the `Deserializer` that it makes
+    // no difference which `Visitor` method is called because the data is
+    // ignored.
+    //
+    // Some deserializers are able to implement this more efficiently than
+    // `deserialize_any`, for example by rapidly skipping over matched
+    // delimiters without paying close attention to the data in between.
+    //
+    // Some formats are not able to implement this at all. Formats that can
+    // implement `deserialize_any` and `deserialize_ignored_any` are known as
+    // self-describing.
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+}
+
+// In order to handle commas correctly when deserializing a JSON array or map,
+// we need to track whether we are on the first element or past the first
+// element.
+struct CommaSeparated<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
+    first: bool,
+}
+
+impl<'a, 'de> CommaSeparated<'a, 'de> {
+    fn new(de: &'a mut Deserializer<'de>) -> Self {
+        CommaSeparated { de, first: true }
+    }
+}
+
+// `SeqAccess` is provided to the `Visitor` to give it the ability to iterate
+// through elements of the sequence.
+impl<'de, 'a> SeqAccess<'de> for CommaSeparated<'a, 'de> {
+    type Error = DbError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, DbError>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        // Check if there are no more elements.
+        if self.de.peek_char()? == ']' {
+            return Ok(None);
+        }
+        // Comma is required before every element except the first.
+        if !self.first && self.de.next_char()? != ',' {
+            return Err(DbError::SerdeError(
+                "Deserialization error: ExpectedArrayComma".to_string(),
+            ));
+        }
+        self.first = false;
+        // Deserialize an array element.
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+}
+
+// `MapAccess` is provided to the `Visitor` to give it the ability to iterate
+// through entries of the map.
+impl<'de, 'a> MapAccess<'de> for CommaSeparated<'a, 'de> {
+    type Error = DbError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, DbError>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        // Check if there are no more entries.
+        if self.de.peek_char()? == '}' {
+            return Ok(None);
+        }
+        // Comma is required before every entry except the first.
+        if !self.first && self.de.next_char()? != ',' {
+            return Err(DbError::SerdeError(
+                "Deserialization error: ExpectedMapComma".to_string(),
+            ));
+        }
+        self.first = false;
+        // Deserialize a map key.
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, DbError>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        // It doesn't make a difference whether the colon is parsed at the end
+        // of `next_key_seed` or at the beginning of `next_value_seed`. In this
+        // case the code is a bit simpler having it here.
+        if self.de.next_char()? != ':' {
+            return Err(DbError::SerdeError(
+                "Deserialization error: ExpectedMapColon".to_string(),
+            ));
+        }
+        // Deserialize a map value.
+        seed.deserialize(&mut *self.de)
+    }
+}
+
+struct Enum<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
+}
+
+impl<'a, 'de> Enum<'a, 'de> {
+    fn new(de: &'a mut Deserializer<'de>) -> Self {
+        Enum { de }
+    }
+}
+
+// `EnumAccess` is provided to the `Visitor` to give it the ability to determine
+// which variant of the enum is supposed to be deserialized.
+//
+// Note that all enum deserialization methods in Serde refer exclusively to the
+// "externally tagged" enum representation.
+impl<'de, 'a> EnumAccess<'de> for Enum<'a, 'de> {
+    type Variant = Self;
+    type Error = DbError;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), DbError>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        // The `deserialize_enum` method parsed a `{` character so we are
+        // currently inside of a map. The seed will be deserializing itself from
+        // the key of the map.
+        let val = seed.deserialize(&mut *self.de)?;
+        // Parse the colon separating map key from value.
+        if self.de.next_char()? == ':' {
+            Ok((val, self))
+        } else {
+            Err(DbError::SerdeError(
+                "Deserialization error: ExpectedMapColon".to_string(),
+            ))
+        }
+    }
+}
+
+// `VariantAccess` is provided to the `Visitor` to give it the ability to see
+// the content of the single variant that it decided to deserialize.
+impl<'de, 'a> VariantAccess<'de> for Enum<'a, 'de> {
+    type Error = DbError;
+
+    // If the `Visitor` expected this variant to be a unit variant, the input
+    // should have been the plain string case handled in `deserialize_enum`.
+    fn unit_variant(self) -> Result<(), DbError> {
+        Err(DbError::SerdeError(
+            "Deserialization error: ExpectedString".to_string(),
+        ))
+    }
+
+    // Newtype variants are represented in JSON as `{ NAME: VALUE }` so
+    // deserialize the value here.
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, DbError>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.de)
+    }
+
+    // Tuple variants are represented in JSON as `{ NAME: [DATA...] }` so
+    // deserialize the sequence of data here.
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        de::Deserializer::deserialize_seq(self.de, visitor)
+    }
+
+    // Struct variants are represented in JSON as `{ NAME: { K: V, ... } }` so
+    // deserialize the inner map here.
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        println!("IN STRUCT_VARIANT");
+        de::Deserializer::deserialize_map(self.de, visitor)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -557,28 +1301,34 @@ mod tests {
 
     #[test]
     fn test_serde_struct() {
-        #[derive(Serialize)]
+        let db_row = db_row! {"value".into() => DbValue::from("foo")};
+        let expected_string = r#"{"value":{"Text":"foo"}}"#;
+        assert_eq!(to_string(&db_row).unwrap(), expected_string);
+        assert_eq!(to_db_row(&db_row).unwrap(), db_row);
+
+        #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Foo {
             bar: u32,
             xyzzy: String,
         }
 
-        let test = Foo {
+        let expected_struct = Foo {
             bar: 1,
             xyzzy: "test".to_string(),
         };
         let expected_string = r#"{"bar":1,"xyzzy":"test"}"#;
-        assert_eq!(to_string(&test).unwrap(), expected_string);
+        assert_eq!(to_string(&expected_struct).unwrap(), expected_string);
 
         let expected_db_row = db_row! {
             "bar".into() => DbValue::from(1_u32),
             "xyzzy".into() => DbValue::from("test"),
         };
-        assert_eq!(to_db_row(&test).unwrap(), expected_db_row);
+        assert_eq!(to_db_row(&expected_struct).unwrap(), expected_db_row);
 
-        let db_row = db_row! {"value".into() => DbValue::from("foo")};
-        let expected_string = r#"{"value":{"Text":"foo"}}"#;
-        assert_eq!(to_string(&db_row).unwrap(), expected_string);
-        assert_eq!(to_db_row(&db_row).unwrap(), db_row);
+        let db_row = db_row! {
+            "bar".into() => DbValue::from(1_u32),
+            "xyzzy".into() => DbValue::from("test"),
+        };
+        assert_eq!(expected_struct, from_db_row(&db_row).unwrap());
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -2,6 +2,7 @@ use crate::{
     core::DbError,
     db_value::{DbRow, DbValue, JsonRow, JsonValue},
 };
+use rust_decimal::Decimal;
 use serde::{
     Deserialize, Serialize,
     de::{
@@ -10,7 +11,10 @@ use serde::{
     },
     ser::{self, SerializeSeq as _},
 };
-use std::ops::{AddAssign, MulAssign, Neg};
+use std::{
+    ops::{AddAssign, MulAssign, Neg},
+    str::FromStr,
+};
 
 // TODO: Most of the comments and docstrings below were copied (initially) verbatim from
 // https://serde.rs/impl-serializer.html. After we adapt that template to our use case these
@@ -61,17 +65,40 @@ where
                 assert_eq!(value.len(), 1);
                 let value = value.iter().collect::<Vec<_>>()[0];
                 let value_type = value.0;
-                let value_value = DbValue::from(value.1.clone());
                 match value_type.to_lowercase().as_str() {
                     "null" => db_row.insert(column.to_string(), DbValue::Null),
-                    "boolean" => db_row.insert(column.to_string(), DbValue::from(value_value)),
-                    "smallinteger" => db_row.insert(column.to_string(), DbValue::from(value_value)),
-                    "integer" => db_row.insert(column.to_string(), DbValue::from(value_value)),
-                    "biginteger" => db_row.insert(column.to_string(), DbValue::from(value_value)),
-                    "real" => db_row.insert(column.to_string(), DbValue::from(value_value)),
-                    "bigreal" => db_row.insert(column.to_string(), DbValue::from(value_value)),
-                    "numeric" => db_row.insert(column.to_string(), DbValue::from(value_value)),
-                    "text" => db_row.insert(column.to_string(), DbValue::from(value_value)),
+                    "boolean" => db_row.insert(
+                        column.to_string(),
+                        DbValue::Boolean(value.1.as_bool().unwrap()),
+                    ),
+                    "smallinteger" => db_row.insert(
+                        column.to_string(),
+                        DbValue::SmallInteger(value.1.as_i64().unwrap().try_into().unwrap()),
+                    ),
+                    "integer" => db_row.insert(
+                        column.to_string(),
+                        DbValue::Integer(value.1.as_i64().unwrap().try_into().unwrap()),
+                    ),
+                    "biginteger" => db_row.insert(
+                        column.to_string(),
+                        DbValue::BigInteger(value.1.as_i64().unwrap()),
+                    ),
+                    "real" => db_row.insert(
+                        column.to_string(),
+                        DbValue::Real(value.1.as_f64().unwrap() as f32),
+                    ),
+                    "bigreal" => db_row.insert(
+                        column.to_string(),
+                        DbValue::BigReal(value.1.as_f64().unwrap()),
+                    ),
+                    "numeric" => db_row.insert(
+                        column.to_string(),
+                        DbValue::Numeric(Decimal::from_str(&value.1.to_string()).unwrap()),
+                    ),
+                    "text" => db_row.insert(
+                        column.to_string(),
+                        DbValue::Text(value.1.as_str().unwrap().to_string()),
+                    ),
                     _ => panic!(),
                 }
             }
@@ -616,30 +643,14 @@ where
                 let value_value = JsonValue::from(value.1.clone());
                 match value_type.to_lowercase().as_str() {
                     "null" => flat_json_row.insert(column.to_string(), JsonValue::Null),
-                    "boolean" => {
-                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
-                    }
-                    "smallinteger" => {
-                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
-                    }
-                    "integer" => {
-                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
-                    }
-                    "biginteger" => {
-                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
-                    }
-                    "real" => {
-                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
-                    }
-                    "bigreal" => {
-                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
-                    }
-                    "numeric" => {
-                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
-                    }
-                    "text" => {
-                        flat_json_row.insert(column.to_string(), JsonValue::from(value_value))
-                    }
+                    "boolean" => flat_json_row.insert(column.to_string(), value_value),
+                    "smallinteger" => flat_json_row.insert(column.to_string(), value_value),
+                    "integer" => flat_json_row.insert(column.to_string(), value_value),
+                    "biginteger" => flat_json_row.insert(column.to_string(), value_value),
+                    "real" => flat_json_row.insert(column.to_string(), value_value),
+                    "bigreal" => flat_json_row.insert(column.to_string(), value_value),
+                    "numeric" => flat_json_row.insert(column.to_string(), value_value),
+                    "text" => flat_json_row.insert(column.to_string(), value_value),
                     _ => panic!(),
                 }
             }
@@ -1304,27 +1315,50 @@ mod tests {
         // Serializing or deserializing a DbRow into a DbRow should yield a DbRow that is
         // identical to the original one:
         let db_row = db_row! {"value".into() => DbValue::from("foo")};
-        assert_eq!(to_db_row(&db_row).unwrap(), db_row);
+        assert_eq!(db_row, to_db_row(&db_row).unwrap());
         // TODO: Not yet working,
-        //assert_eq!(from_db_row::<DbRow>(&db_row).unwrap(), db_row);
+        //assert_eq!(db_row, from_db_row(&db_row).unwrap());
+
+        // TODO: Because we are relying on JSON serialization it is impossible to distinguish
+        // between different types of numbers. So for now we are setting all of the struct's
+        // number fields to i64. Once we remove the serde_json dependency we will need to test
+        // structs that have many types of numbers.
 
         // Serializing and deserializing an arbitrary struct to a DbRow:
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
-        struct Foo {
-            bar: u32,
-            xyzzy: String,
+        struct TestStruct {
+            boolean: bool,
+            smallint: i64,    // TODO: i16
+            mediumint: i64,   // TODO: i32
+            bigint: i64,      // TODO: i64
+            smallfloat: i64,  // TODO: f32
+            bigfloat: i64,    // TODO: f64
+            biggerfloat: i64, // TODO: decimal
+            text: String,
         }
 
-        let expected_struct = Foo {
-            bar: 1,
-            xyzzy: "test".to_string(),
+        let expected_struct = TestStruct {
+            boolean: true,
+            smallint: 1,
+            mediumint: 1,
+            bigint: 1,
+            smallfloat: 1,
+            bigfloat: 1,
+            biggerfloat: 1,
+            text: 1.to_string(),
         };
 
         let expected_db_row = db_row! {
-            "bar".into() => DbValue::from(1_u32),
-            "xyzzy".into() => DbValue::from("test"),
+            "boolean".into() => DbValue::from(true),
+            "smallint".into() => DbValue::from(1_i64),
+            "mediumint".into() => DbValue::from(1_i64),
+            "bigint".into() => DbValue::from(1_i64),
+            "smallfloat".into() => DbValue::from(1_i64),
+            "bigfloat".into() => DbValue::from(1_i64),
+            "biggerfloat".into() => DbValue::from(1_i64),
+            "text".into() => DbValue::from("1"),
         };
-        assert_eq!(to_db_row(&expected_struct).unwrap(), expected_db_row);
+        assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
         assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,554 @@
+use crate::core::DbError;
+use serde::{
+    Serialize,
+    ser::{self, SerializeSeq as _},
+};
+
+// TODO: Most of the comments and docstrings below were copied (initially) verbatim from
+// https://serde.rs/impl-serializer.html. After we adapt that template to our use case these
+// need to be updated.
+
+/// Used for serialization / deserialization of a [DbRow] to/from a struct
+pub struct Serializer {
+    output: String,
+}
+
+// By convention, the public API of a Serde serializer is one or more `to_abc`
+// functions such as `to_string`, `to_bytes`, or `to_writer` depending on what
+// Rust types the serializer is able to produce as output.
+//
+// This basic serializer supports only `to_string`.
+
+pub fn to_string<T>(value: &T) -> Result<String, DbError>
+where
+    T: Serialize,
+{
+    let mut serializer = Serializer {
+        output: String::new(),
+    };
+    value.serialize(&mut serializer)?;
+    Ok(serializer.output)
+}
+
+impl<'a> ser::Serializer for &'a mut Serializer {
+    // The output type produced by this `Serializer` during successful
+    // serialization. Most serializers that produce text or binary output should
+    // set `Ok = ()` and serialize into an `io::Write` or buffer contained
+    // within the `Serializer` instance, as happens here. Serializers that build
+    // in-memory data structures may be simplified by using `Ok` to propagate
+    // the data structure around.
+    type Ok = ();
+
+    // The error type when some error occurs during serialization.
+    type Error = DbError;
+
+    // Associated types for keeping track of additional state while serializing
+    // compound data structures like sequences and maps. In this case no
+    // additional state is required beyond what is already stored in the
+    // Serializer struct.
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    // Here we go with the simple methods. The following 12 methods receive one
+    // of the primitive types of the data model and map it to JSON by appending
+    // into the output string.
+
+    fn serialize_bool(self, value: bool) -> Result<(), Self::Error> {
+        self.output += match value {
+            true => "true",
+            false => "false",
+        };
+        Ok(())
+    }
+
+    // JSON does not distinguish between different sizes of integers, so all
+    // signed integers will be serialized the same and all unsigned integers
+    // will be serialized the same. Other formats, especially compact binary
+    // formats, may need independent logic for the different sizes.
+
+    fn serialize_i8(self, value: i8) -> Result<(), Self::Error> {
+        self.serialize_i64(i64::from(value))
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<(), Self::Error> {
+        self.serialize_i64(i64::from(value))
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<(), Self::Error> {
+        self.serialize_i64(i64::from(value))
+    }
+
+    // Not particularly efficient but this is example code anyway. A more
+    // performant approach would be to use the `itoa` crate.
+    fn serialize_i64(self, value: i64) -> Result<(), Self::Error> {
+        self.output += &value.to_string();
+        Ok(())
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<(), Self::Error> {
+        self.serialize_u64(u64::from(value))
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<(), Self::Error> {
+        self.serialize_u64(u64::from(value))
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<(), Self::Error> {
+        self.serialize_u64(u64::from(value))
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<(), Self::Error> {
+        self.output += &value.to_string();
+        Ok(())
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<(), Self::Error> {
+        self.serialize_f64(f64::from(value))
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<(), Self::Error> {
+        self.output += &value.to_string();
+        Ok(())
+    }
+
+    // Serialize a char as a single-character string. Other formats may
+    // represent this differently.
+    fn serialize_char(self, value: char) -> Result<(), Self::Error> {
+        self.serialize_str(&value.to_string())
+    }
+
+    // This only works for strings that don't require escape sequences but you
+    // get the idea. For example it would emit invalid JSON if the input string
+    // contains a '"' character.
+    fn serialize_str(self, value: &str) -> Result<(), Self::Error> {
+        self.output += "\"";
+        self.output += value;
+        self.output += "\"";
+        Ok(())
+    }
+
+    // Serialize a byte array as an array of bytes. Could also use a base64
+    // string here. Binary formats will typically represent byte arrays more
+    // compactly.
+    fn serialize_bytes(self, values: &[u8]) -> Result<(), Self::Error> {
+        let mut seq = self.serialize_seq(Some(values.len()))?;
+        for byte in values {
+            seq.serialize_element(byte)?;
+        }
+        seq.end()
+    }
+
+    // An absent optional is represented as the JSON `null`.
+    fn serialize_none(self) -> Result<(), Self::Error> {
+        self.serialize_unit()
+    }
+
+    // A present optional is represented as just the contained value. Note that
+    // this is a lossy representation. For example the values `Some(())` and
+    // `None` both serialize as just `null`. Unfortunately this is typically
+    // what people expect when working with JSON. Other formats are encouraged
+    // to behave more intelligently if possible.
+    fn serialize_some<T>(self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    // In Serde, unit means an anonymous value containing no data. Map this to
+    // JSON as `null`.
+    fn serialize_unit(self) -> Result<(), Self::Error> {
+        self.output += "null";
+        Ok(())
+    }
+
+    // Unit struct means a named value containing no data. Again, since there is
+    // no data, map this to JSON as `null`. There is no need to serialize the
+    // name in most formats.
+    fn serialize_unit_struct(self, _name: &str) -> Result<(), Self::Error> {
+        self.serialize_unit()
+    }
+
+    // When serializing a unit variant (or any other kind of variant), formats
+    // can choose whether to keep track of it by index or by name. Binary
+    // formats typically use the index of the variant and human-readable formats
+    // typically use the name.
+    fn serialize_unit_variant(
+        self,
+        _name: &str,
+        _variant_index: u32,
+        variant: &str,
+    ) -> Result<(), Self::Error> {
+        self.serialize_str(variant)
+    }
+
+    // As is done here, serializers are encouraged to treat newtype structs as
+    // insignificant wrappers around the data they contain.
+    fn serialize_newtype_struct<T>(self, _name: &str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    // Note that newtype variant (and all of the other variant serialization
+    // methods) refer exclusively to the "externally tagged" enum
+    // representation.
+    //
+    // Serialize this to JSON in externally tagged form as `{ NAME: VALUE }`.
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &str,
+        _variant_index: u32,
+        variant: &str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.output += "{";
+        variant.serialize(&mut *self)?;
+        self.output += ":";
+        value.serialize(&mut *self)?;
+        self.output += "}";
+        Ok(())
+    }
+
+    // Now we get to the serialization of compound types.
+    //
+    // The start of the sequence, each value, and the end are three separate
+    // method calls. This one is responsible only for serializing the start,
+    // which in JSON is `[`.
+    //
+    // The length of the sequence may or may not be known ahead of time. This
+    // doesn't make a difference in JSON because the length is not represented
+    // explicitly in the serialized form. Some serializers may only be able to
+    // support sequences for which the length is known up front.
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        self.output += "[";
+        Ok(self)
+    }
+
+    // Tuples look just like sequences in JSON. Some formats may be able to
+    // represent tuples more efficiently by omitting the length, since tuple
+    // means that the corresponding `Deserialize implementation will know the
+    // length without needing to look at the serialized data.
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    // Tuple structs look just like sequences in JSON.
+    fn serialize_tuple_struct(
+        self,
+        _name: &str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    // Tuple variants are represented in JSON as `{ NAME: [DATA...] }`. Again
+    // this method is only responsible for the externally tagged representation.
+    fn serialize_tuple_variant(
+        self,
+        _name: &str,
+        _variant_index: u32,
+        variant: &str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.output += "{";
+        variant.serialize(&mut *self)?;
+        self.output += ":[";
+        Ok(self)
+    }
+
+    // Maps are represented in JSON as `{ K: V, K: V, ... }`.
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.output += "{";
+        Ok(self)
+    }
+
+    // Structs look just like maps in JSON. In particular, JSON requires that we
+    // serialize the field names of the struct. Other formats may be able to
+    // omit the field names when serializing structs because the corresponding
+    // Deserialize implementation is required to know what the keys are without
+    // looking at the serialized data.
+    fn serialize_struct(
+        self,
+        _name: &str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    // Struct variants are represented in JSON as `{ NAME: { K: V, ... } }`.
+    // This is the externally tagged representation.
+    fn serialize_struct_variant(
+        self,
+        _name: &str,
+        _variant_index: u32,
+        variant: &str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.output += "{";
+        variant.serialize(&mut *self)?;
+        self.output += ":{";
+        Ok(self)
+    }
+}
+
+// The following 7 impls deal with the serialization of compound types like
+// sequences and maps. Serialization of such types is begun by a Serializer
+// method and followed by zero or more calls to serialize individual elements of
+// the compound type and one call to end the compound type.
+//
+// This impl is SerializeSeq so these methods are called after `serialize_seq`
+// is called on the Serializer.
+
+impl<'a> ser::SerializeSeq for &'a mut Serializer {
+    // Must match the `Ok` type of the serializer.
+    type Ok = ();
+    // Must match the `Error` type of the serializer.
+    type Error = DbError;
+
+    // Serialize a single element of the sequence.
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('[') {
+            self.output += ",";
+        }
+        value.serialize(&mut **self)
+    }
+
+    // Close the sequence.
+    fn end(self) -> Result<(), Self::Error> {
+        self.output += "]";
+        Ok(())
+    }
+}
+
+// Same thing but for tuples.
+impl<'a> ser::SerializeTuple for &'a mut Serializer {
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('[') {
+            self.output += ",";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        self.output += "]";
+        Ok(())
+    }
+}
+
+// Same thing but for tuple structs.
+impl<'a> ser::SerializeTupleStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('[') {
+            self.output += ",";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        self.output += "]";
+        Ok(())
+    }
+}
+
+// Tuple variants are a little different. Refer back to the
+// `serialize_tuple_variant` method above:
+//
+//    self.output += "{";
+//    variant.serialize(&mut *self)?;
+//    self.output += ":[";
+//
+// So the `end` method in this impl is responsible for closing both the `]` and
+// the `}`.
+impl<'a> ser::SerializeTupleVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('[') {
+            self.output += ",";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        self.output += "]}";
+        Ok(())
+    }
+}
+
+// Some `Serialize` types are not able to hold a key and value in memory at the
+// same time so `SerializeMap` implementations are required to support
+// `serialize_key` and `serialize_value` individually.
+//
+// There is a third optional method on the `SerializeMap` trait. The
+// `serialize_entry` method allows serializers to optimize for the case where
+// key and value are both available simultaneously. In JSON it doesn't make a
+// difference so the default behavior for `serialize_entry` is fine.
+impl<'a> ser::SerializeMap for &'a mut Serializer {
+    type Ok = ();
+    type Error = DbError;
+
+    // The Serde data model allows map keys to be any serializable type. JSON
+    // only allows string keys so the implementation below will produce invalid
+    // JSON if the key serializes as something other than a string.
+    //
+    // A real JSON serializer would need to validate that map keys are strings.
+    // This can be done by using a different Serializer to serialize the key
+    // (instead of `&mut **self`) and having that other serializer only
+    // implement `serialize_str` and return an error on any other data type.
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('{') {
+            self.output += ",";
+        }
+        key.serialize(&mut **self)
+    }
+
+    // It doesn't make a difference whether the colon is printed at the end of
+    // `serialize_key` or at the beginning of `serialize_value`. In this case
+    // the code is a bit simpler having it here.
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.output += ":";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        self.output += "}";
+        Ok(())
+    }
+}
+
+// Structs are like maps in which the keys are constrained to be compile-time
+// constant strings.
+impl<'a> ser::SerializeStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('{') {
+            self.output += ",";
+        }
+        key.serialize(&mut **self)?;
+        self.output += ":";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        self.output += "}";
+        Ok(())
+    }
+}
+
+// Similar to `SerializeTupleVariant`, here the `end` method is responsible for
+// closing both of the curly braces opened by `serialize_struct_variant`.
+impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('{') {
+            self.output += ",";
+        }
+        key.serialize(&mut **self)?;
+        self.output += ":";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        self.output += "}}";
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serde_struct() {
+        #[derive(Serialize)]
+        struct Test {
+            int: u32,
+            seq: Vec<&'static str>,
+        }
+
+        let test = Test {
+            int: 1,
+            seq: vec!["a", "b"],
+        };
+        let expected = r#"{"int":1,"seq":["a","b"]}"#;
+        assert_eq!(to_string(&test).unwrap(), expected);
+
+        // DbRow tests begin here:
+
+        let db_row = db_row! {"value".into() => DbValue::from("foo")};
+        let expected = r#"{"value":{"Text":"foo"}}"#;
+        assert_eq!(to_string(&db_row).unwrap(), expected);
+    }
+
+    // #[test]
+    // fn test_serde_enum() {
+    //     #[derive(Serialize)]
+    //     enum E {
+    //         Unit,
+    //         Newtype(u32),
+    //         Tuple(u32, u32),
+    //         Struct { a: u32 },
+    //     }
+
+    //     let u = E::Unit;
+    //     let expected = r#""Unit""#;
+    //     assert_eq!(to_string(&u).unwrap(), expected);
+
+    //     let n = E::Newtype(1);
+    //     let expected = r#"{"Newtype":1}"#;
+    //     assert_eq!(to_string(&n).unwrap(), expected);
+
+    //     let t = E::Tuple(1, 2);
+    //     let expected = r#"{"Tuple":[1,2]}"#;
+    //     assert_eq!(to_string(&t).unwrap(), expected);
+
+    //     let s = E::Struct { a: 1 };
+    //     let expected = r#"{"Struct":{"a":1}}"#;
+    //     assert_eq!(to_string(&s).unwrap(), expected);
+    // }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1301,11 +1301,14 @@ mod tests {
 
     #[test]
     fn test_serde_struct() {
+        // Serializing or deserializing a DbRow into a DbRow should yield a DbRow that is
+        // identical to the original one:
         let db_row = db_row! {"value".into() => DbValue::from("foo")};
-        let expected_string = r#"{"value":{"Text":"foo"}}"#;
-        assert_eq!(to_string(&db_row).unwrap(), expected_string);
         assert_eq!(to_db_row(&db_row).unwrap(), db_row);
+        // TODO: Not yet working,
+        //assert_eq!(from_db_row::<DbRow>(&db_row).unwrap(), db_row);
 
+        // Serializing and deserializing an arbitrary struct to a DbRow:
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct Foo {
             bar: u32,
@@ -1316,19 +1319,12 @@ mod tests {
             bar: 1,
             xyzzy: "test".to_string(),
         };
-        let expected_string = r#"{"bar":1,"xyzzy":"test"}"#;
-        assert_eq!(to_string(&expected_struct).unwrap(), expected_string);
 
         let expected_db_row = db_row! {
             "bar".into() => DbValue::from(1_u32),
             "xyzzy".into() => DbValue::from("test"),
         };
         assert_eq!(to_db_row(&expected_struct).unwrap(), expected_db_row);
-
-        let db_row = db_row! {
-            "bar".into() => DbValue::from(1_u32),
-            "xyzzy".into() => DbValue::from("test"),
-        };
-        assert_eq!(expected_struct, from_db_row(&db_row).unwrap());
+        assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -11,14 +11,16 @@ use serde::{
     ser,
 };
 
-/// Convert the given struct to a [DbRow]. For this to be successful, the struct
+/// Convert the given supported struct to a [DbRow]. For this to be successful, the struct
 /// must be a "normal struct" of the form:
 ///
+/// ```ignore
 /// struct NormalStruct {
-///   field1: type1,
-///   field2: type2,
+///   field1: type1, // or Option<type1>
+///   field2: type2, // or Option<type2>
 ///   ...
 /// }
+/// ```
 ///
 /// where type1, type2, ... are among the primitive types associated with
 /// the different kinds of [DbValue]. Other field types, and other types of
@@ -57,11 +59,13 @@ where
 /// Convert the given [DbRow] to a supported struct. For this to be successful,
 /// the struct must be a "normal struct" of the form:
 ///
+/// ```ignore
 /// struct NormalStruct {
-///   field1: type1,
-///   field2: type2,
+///   field1: type1, // or Option<type1>
+///   field2: type2, // or Option<type2>
 ///   ...
 /// }
+/// ```
 ///
 /// where type1, type2, ... are among the primitive types associated with
 /// the different kinds of [DbValue]. Other field types, and other types of
@@ -79,9 +83,10 @@ where
     if deserializer.keys.is_empty() && deserializer.values.is_empty() {
         Ok(t)
     } else {
-        Err(DbError::SerdeError(
-            "Deserialization error: Leftover input".to_string(),
-        ))
+        Err(DbError::SerdeError(format!(
+            "Deserialization error: Leftover keys: {:?} and values: {:?}",
+            deserializer.keys, deserializer.values
+        )))
     }
 }
 
@@ -155,15 +160,11 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
     type SerializeStruct = Self;
     type SerializeStructVariant = Self;
 
+    // Primitive types
+
     fn serialize_bool(self, value: bool) -> Result<(), Self::Error> {
         self.values.push(DbValue::from(value));
         Ok(())
-    }
-
-    fn serialize_i8(self, _value: i8) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing i8 is not supported".to_string(),
-        ));
     }
 
     fn serialize_i16(self, value: i16) -> Result<(), Self::Error> {
@@ -179,12 +180,6 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
     fn serialize_i64(self, value: i64) -> Result<(), Self::Error> {
         self.values.push(DbValue::from(value));
         Ok(())
-    }
-
-    fn serialize_u8(self, _value: u8) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing u8 is not supported".to_string(),
-        ));
     }
 
     fn serialize_u16(self, value: u16) -> Result<(), Self::Error> {
@@ -212,22 +207,12 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
         Ok(())
     }
 
-    fn serialize_char(self, _value: char) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing char is not supported".to_string(),
-        ));
-    }
-
     fn serialize_str(self, value: &str) -> Result<(), Self::Error> {
         self.values.push(DbValue::from(value));
         Ok(())
     }
 
-    fn serialize_bytes(self, _values: &[u8]) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing bytes is not supported".to_string(),
-        ));
-    }
+    // Options
 
     fn serialize_none(self) -> Result<(), Self::Error> {
         self.serialize_unit()
@@ -243,6 +228,46 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
     fn serialize_unit(self) -> Result<(), Self::Error> {
         self.values.push(DbValue::Null);
         Ok(())
+    }
+
+    // More complex types:
+
+    fn serialize_struct(
+        self,
+        _name: &str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(self)
+    }
+
+    // Unsupported types:
+
+    fn serialize_i8(self, _value: i8) -> Result<(), Self::Error> {
+        return Err(DbError::SerdeError(
+            "Serializing i8 is not supported".to_string(),
+        ));
+    }
+
+    fn serialize_u8(self, _value: u8) -> Result<(), Self::Error> {
+        return Err(DbError::SerdeError(
+            "Serializing u8 is not supported".to_string(),
+        ));
+    }
+
+    fn serialize_char(self, _value: char) -> Result<(), Self::Error> {
+        return Err(DbError::SerdeError(
+            "Serializing char is not supported".to_string(),
+        ));
+    }
+
+    fn serialize_bytes(self, _values: &[u8]) -> Result<(), Self::Error> {
+        return Err(DbError::SerdeError(
+            "Serializing bytes is not supported".to_string(),
+        ));
     }
 
     fn serialize_unit_struct(self, _name: &str) -> Result<(), Self::Error> {
@@ -318,18 +343,6 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
         return Err(DbError::SerdeError(
             "Serializing tuple variant is not supported".to_string(),
         ));
-    }
-
-    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Ok(self)
-    }
-
-    fn serialize_struct(
-        self,
-        _name: &str,
-        len: usize,
-    ) -> Result<Self::SerializeStruct, Self::Error> {
-        self.serialize_map(Some(len))
     }
 
     fn serialize_struct_variant(
@@ -511,7 +524,7 @@ impl<'a> ser::SerializeTupleVariant for &'a mut DbRowSerializer {
 ////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug)]
-pub struct DbRowDeserializer<'de> {
+struct DbRowDeserializer<'de> {
     /// The keys of the input [DbRow].
     keys: Vec<&'de str>,
     /// The values of the input [DbRow].
@@ -519,18 +532,18 @@ pub struct DbRowDeserializer<'de> {
 }
 
 impl<'de> DbRowDeserializer<'de> {
-    pub fn from_db_row(input: &'de DbRow) -> Self {
+    fn from_db_row(input: &'de DbRow) -> Self {
         DbRowDeserializer {
             keys: input.map.keys().map(|s| s.as_str()).collect::<Vec<_>>(),
             values: input.map.values().collect::<Vec<_>>(),
         }
     }
 
-    pub fn pop_key(&mut self) -> Option<&'de str> {
+    fn pop_key(&mut self) -> Option<&'de str> {
         self.keys.pop()
     }
 
-    pub fn pop_value(&mut self) -> Option<&'de DbValue> {
+    fn pop_value(&mut self) -> Option<&'de DbValue> {
         self.values.pop()
     }
 }
@@ -538,14 +551,7 @@ impl<'de> DbRowDeserializer<'de> {
 impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     type Error = DbError;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'any' is not supported".to_string(),
-        ));
-    }
+    // Primitives:
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
@@ -559,15 +565,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
                 visitor.visit_bool(value)
             }
         }
-    }
-
-    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'i8' is not supported".to_string(),
-        ));
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, DbError>
@@ -612,6 +609,112 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         }
     }
 
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_f32().unwrap();
+                visitor.visit_f32(value)
+            }
+        }
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_f64().unwrap();
+                visitor.visit_f64(value)
+            }
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_str().unwrap();
+                visitor.visit_borrowed_str(value)
+            }
+        }
+    }
+
+    // Options:
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        let value = self.values.last().unwrap();
+        match value {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        let value = self.pop_value().unwrap();
+        // TODO: Remove the assert
+        assert_eq!(*value, DbValue::Null);
+        visitor.visit_unit()
+    }
+
+    // More complex types:
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_map(self)
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // TODO: Remove unwraps here and elsewhere.
+        let key = self.pop_key().unwrap();
+        visitor.visit_borrowed_str(key)
+    }
+
+    // Unsupported types:
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        return Err(DbError::SerdeError(
+            "Deserializing 'i8' is not supported".to_string(),
+        ));
+    }
+
     fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
@@ -648,34 +751,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         ));
     }
 
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        match self.values.last().unwrap() {
-            DbValue::Null => self.deserialize_unit(visitor),
-            _ => {
-                let value = self.pop_value().unwrap();
-                let value = value.as_f32().unwrap();
-                visitor.visit_f32(value)
-            }
-        }
-    }
-
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        match self.values.last().unwrap() {
-            DbValue::Null => self.deserialize_unit(visitor),
-            _ => {
-                let value = self.pop_value().unwrap();
-                let value = value.as_f64().unwrap();
-                visitor.visit_f64(value)
-            }
-        }
-    }
-
     fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
@@ -694,20 +769,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         ));
     }
 
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        match self.values.last().unwrap() {
-            DbValue::Null => self.deserialize_unit(visitor),
-            _ => {
-                let value = self.pop_value().unwrap();
-                let value = value.as_str().unwrap();
-                visitor.visit_borrowed_str(value)
-            }
-        }
-    }
-
     fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
@@ -724,27 +785,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         return Err(DbError::SerdeError(
             "Deserializing 'byte_buf' is not supported".to_string(),
         ));
-    }
-
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        let value = self.values.last().unwrap();
-        match value {
-            DbValue::Null => self.deserialize_unit(visitor),
-            _ => visitor.visit_some(self),
-        }
-    }
-
-    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        let value = self.pop_value().unwrap();
-        // TODO: Remove the assert
-        assert_eq!(*value, DbValue::Null);
-        visitor.visit_unit()
     }
 
     fn deserialize_unit_struct<V>(
@@ -805,25 +845,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         ));
     }
 
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_map(self)
-    }
-
-    fn deserialize_struct<V>(
-        self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_map(visitor)
-    }
-
     fn deserialize_enum<V>(
         self,
         _name: &'static str,
@@ -838,21 +859,21 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         ));
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        // TODO: Remove unwraps here and elsewhere.
-        let key = self.pop_key().unwrap();
-        visitor.visit_borrowed_str(key)
-    }
-
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
         return Err(DbError::SerdeError(
             "Deserializing 'ignored_any' is not supported".to_string(),
+        ));
+    }
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        return Err(DbError::SerdeError(
+            "Deserializing 'any' is not supported".to_string(),
         ));
     }
 }
@@ -944,9 +965,9 @@ mod tests {
         };
         assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
         assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
-        //assert_eq!(
-        //    expected_struct,
-        //    from_db_row_indirect(&expected_db_row).unwrap()
-        //);
+        assert_eq!(
+            expected_struct,
+            from_db_row_indirect(&expected_db_row).unwrap()
+        );
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -167,6 +167,11 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
         Ok(())
     }
 
+    fn serialize_i8(self, value: i8) -> Result<(), Self::Error> {
+        self.values.push(DbValue::from(value));
+        Ok(())
+    }
+
     fn serialize_i16(self, value: i16) -> Result<(), Self::Error> {
         self.values.push(DbValue::from(value));
         Ok(())
@@ -178,6 +183,11 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
     }
 
     fn serialize_i64(self, value: i64) -> Result<(), Self::Error> {
+        self.values.push(DbValue::from(value));
+        Ok(())
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<(), Self::Error> {
         self.values.push(DbValue::from(value));
         Ok(())
     }
@@ -209,6 +219,11 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
 
     fn serialize_str(self, value: &str) -> Result<(), Self::Error> {
         self.values.push(DbValue::from(value));
+        Ok(())
+    }
+
+    fn serialize_char(self, value: char) -> Result<(), Self::Error> {
+        self.values.push(DbValue::from(value.to_string()));
         Ok(())
     }
 
@@ -245,24 +260,6 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
     }
 
     // Unsupported types:
-
-    fn serialize_i8(self, _value: i8) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing i8 is not supported".to_string(),
-        ));
-    }
-
-    fn serialize_u8(self, _value: u8) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing u8 is not supported".to_string(),
-        ));
-    }
-
-    fn serialize_char(self, _value: char) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing char is not supported".to_string(),
-        ));
-    }
 
     fn serialize_bytes(self, _values: &[u8]) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
@@ -567,6 +564,20 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         }
     }
 
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_i16().unwrap();
+                visitor.visit_i16(value)
+            }
+        }
+    }
+
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
@@ -609,6 +620,62 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         }
     }
 
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_u8().unwrap();
+                visitor.visit_u8(value)
+            }
+        }
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_u16().unwrap();
+                visitor.visit_u16(value)
+            }
+        }
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_u32().unwrap();
+                visitor.visit_u32(value)
+            }
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_u64().unwrap();
+                visitor.visit_u64(value)
+            }
+        }
+    }
+
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
@@ -638,6 +705,34 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_str().unwrap();
+                visitor.visit_borrowed_str(value)
+            }
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_str().unwrap();
+                visitor.visit_borrowed_str(value)
+            }
+        }
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
@@ -706,69 +801,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     }
 
     // Unsupported types:
-
-    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'i8' is not supported".to_string(),
-        ));
-    }
-
-    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'u8' is not supported".to_string(),
-        ));
-    }
-
-    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'u16' is not supported".to_string(),
-        ));
-    }
-
-    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'u32' is not supported".to_string(),
-        ));
-    }
-
-    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'u64' is not supported".to_string(),
-        ));
-    }
-
-    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'char' is not supported".to_string(),
-        ));
-    }
-
-    fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        return Err(DbError::SerdeError(
-            "Deserializing 'str' is not supported".to_string(),
-        ));
-    }
 
     fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
@@ -914,6 +946,10 @@ mod tests {
         struct TestStruct {
             boolean: bool,
             boolean_opt: Option<bool>,
+            tinyint: i8,
+            tinyint_opt: Option<i8>,
+            tiny_unsigned: u8,
+            tiny_unsigned_opt: Option<u8>,
             smallint: i16,
             smallint_opt: Option<i16>,
             mediumint: i32,
@@ -924,14 +960,18 @@ mod tests {
             smallfloat_opt: Option<f32>,
             bigfloat: f64,
             bigfloat_opt: Option<f64>,
-            // biggerfloat: Decimal,
             text: String,
             text_opt: Option<String>,
+            // biggerfloat: Decimal,
         }
 
         let expected_struct = TestStruct {
             boolean: true,
             boolean_opt: Some(true),
+            tinyint: 1,
+            tinyint_opt: Some(1),
+            tiny_unsigned: 1,
+            tiny_unsigned_opt: None,
             smallint: 1,
             smallint_opt: None,
             mediumint: 1,
@@ -942,14 +982,18 @@ mod tests {
             smallfloat_opt: Some(1_f32),
             bigfloat: 1_f64,
             bigfloat_opt: None,
-            // biggerfloat: dec!(1),
             text: 1.to_string(),
             text_opt: Some(1.to_string()),
+            // biggerfloat: dec!(1),
         };
 
         let expected_db_row = db_row! {
             "boolean" => true,
             "boolean_opt" => true,
+            "tinyint" => 1_i16,
+            "tinyint_opt" => 1_i16,
+            "tiny_unsigned" => 1_i16,
+            "tiny_unsigned_opt" => DbValue::Null,
             "smallint" => 1_i16,
             "smallint_opt" => DbValue::Null,
             "mediumint" => 1_i32,
@@ -960,9 +1004,9 @@ mod tests {
             "smallfloat_opt" => 1_f32,
             "bigfloat" => 1_f64,
             "bigfloat_opt" => DbValue::Null,
-            // "biggerfloat" => 1_i64,
             "text" => "1",
             "text_opt" => "1",
+            // "biggerfloat" => 1_i64,
         };
         assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
         assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -10,6 +10,7 @@ use serde::{
     de::{self, Visitor},
     ser,
 };
+use serde_json::{json, value::Serializer as JsonValueSerializer};
 
 /// Convert the given supported struct to a [DbRow]. For this to be successful, the struct
 /// must be a "normal struct" of the form:
@@ -35,6 +36,8 @@ where
     let mut serializer = DbRowSerializer {
         keys: vec![],
         values: vec![],
+        skip: 0,
+        inner_value: JsonValue::Null,
     };
     value.serialize(&mut serializer)?;
     let keys = serializer.keys;
@@ -138,6 +141,8 @@ struct DbRowSerializer {
     keys: Vec<String>,
     /// The values of the output [DbRow].
     values: Vec<DbValue>,
+    skip: usize,
+    inner_value: JsonValue,
 }
 
 impl<'a> ser::Serializer for &'a mut DbRowSerializer {
@@ -249,10 +254,18 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
 
     fn serialize_struct(
         self,
-        _name: &str,
+        name: &str,
         len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        self.serialize_map(Some(len))
+        println!("serliaize_struct {name}");
+        if self.keys.len() > 0 {
+            self.skip = len;
+            self.inner_value = json!({});
+            // self.values.push(DbValue::from("SKIPPED"));
+            Ok(self)
+        } else {
+            self.serialize_map(Some(len))
+        }
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
@@ -268,20 +281,24 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
     }
 
     fn serialize_unit_struct(self, _name: &str) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing unit struct is not supported".to_string(),
-        ));
+        // TODO: I think that I'd prefer to store DbValue::Text(name),
+        // and have the deserializer ignore it.
+        self.values.push(DbValue::Null);
+        Ok(())
     }
 
     fn serialize_unit_variant(
         self,
         _name: &str,
         _variant_index: u32,
-        _variant: &str,
+        variant: &str,
     ) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing unit variant is not supported".to_string(),
-        ));
+        // TODO: I don't like the extra double-quotes here,
+        // but serde_json wants them for deserializing,
+        // and I get a lifetime error when I try to add them
+        // during the deserializing step.
+        self.values.push(DbValue::from(format!(r#""{variant}""#)));
+        Ok(())
     }
 
     fn serialize_newtype_struct<T>(self, _name: &str, _value: &T) -> Result<(), Self::Error>
@@ -364,12 +381,35 @@ impl<'a> ser::SerializeStruct for &'a mut DbRowSerializer {
     where
         T: ?Sized + Serialize,
     {
-        self.keys.push(key.to_string());
-        value.serialize(&mut **self)?;
+        println!("SerializeStruct::serialize_field({key})");
+        if self.skip > 0 {
+            // println!("skipping!");
+            self.skip -= 1;
+            // self.keys.push(key.to_string());
+            // self.skip_field(key)?;
+            let json_serializer = JsonValueSerializer;
+            let json_value = value
+                .serialize(json_serializer)
+                .map_err(|err| DbError::SerdeError(err.to_string()))?;
+            println!("ser {json_value:?} {:?}", self.inner_value);
+            let inner = self.inner_value.as_object_mut().unwrap();
+            inner.insert(key.to_string(), json_value);
+        } else {
+            self.keys.push(key.to_string());
+            value.serialize(&mut **self)?;
+        }
         Ok(())
     }
 
     fn end(self) -> Result<(), DbError> {
+        println!("SerializeStruct::end(): {:?}", self.inner_value);
+        if self.inner_value != JsonValue::Null {
+            let json_string = serde_json::to_string(&self.inner_value)
+                .map_err(|err| DbError::SerdeError(err.to_string()))?;
+            self.values.push(DbValue::Text(json_string));
+            self.inner_value = JsonValue::Null;
+        }
+
         Ok(())
     }
 }
@@ -398,7 +438,7 @@ impl<'a> ser::SerializeStructVariant for &'a mut DbRowSerializer {
 
 // Although a [DbRow] is essentially a wrapper around an IndexMap, when one is serialized,
 // the serialization begins with our implementation of SerializeStruct and thus does not require
-// us to explicitly implement actually working code for the implemetation of SerializeMap, because
+// us to explicitly implement actually working code for the implemetation of , because
 // the map is serialized, instead, via the call to value.serialize() (see above).
 impl<'a> ser::SerializeMap for &'a mut DbRowSerializer {
     // These need to match the `Ok` and `Error` types of DbRowSerializer:
@@ -521,7 +561,7 @@ impl<'a> ser::SerializeTupleVariant for &'a mut DbRowSerializer {
 ////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug)]
-struct DbRowDeserializer<'de> {
+pub(crate) struct DbRowDeserializer<'de> {
     /// The keys of the input [DbRow].
     keys: Vec<&'de str>,
     /// The values of the input [DbRow].
@@ -529,7 +569,7 @@ struct DbRowDeserializer<'de> {
 }
 
 impl<'de> DbRowDeserializer<'de> {
-    fn from_db_row(input: &'de DbRow) -> Self {
+    pub(crate) fn from_db_row(input: &'de DbRow) -> Self {
         DbRowDeserializer {
             keys: input.map.keys().map(|s| s.as_str()).collect::<Vec<_>>(),
             values: input.map.values().collect::<Vec<_>>(),
@@ -774,14 +814,22 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
 
     fn deserialize_struct<V>(
         self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
+        name: &'static str,
+        fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_map(visitor)
+        println!("deserialize_struct {name}");
+        if self.keys == fields {
+            self.deserialize_map(visitor)
+        } else {
+            let value = self.pop_value().unwrap().as_str().unwrap();
+            serde_json::Deserializer::from_str(value)
+                .deserialize_struct(name, fields, visitor)
+                .map_err(|err| DbError::SerdeError(err.to_string()))
+        }
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DbError>
@@ -823,14 +871,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     fn deserialize_unit_struct<V>(
         self,
         _name: &'static str,
-        _visitor: V,
+        visitor: V,
     ) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        return Err(DbError::SerdeError(
-            "Deserializing 'unit_struct' is not supported".to_string(),
-        ));
+        println!("deserialize_unit_struct");
+        self.pop_value().unwrap();
+        visitor.visit_unit()
     }
 
     fn deserialize_newtype_struct<V>(
@@ -880,16 +928,18 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
 
     fn deserialize_enum<V>(
         self,
-        _name: &'static str,
-        _variants: &'static [&'static str],
-        _visitor: V,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
     ) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        return Err(DbError::SerdeError(
-            "Deserializing 'enum' is not supported".to_string(),
-        ));
+        // println!("deserialize enum {name} {variants:?}");
+        let value = self.pop_value().unwrap().as_str().unwrap();
+        serde_json::Deserializer::from_str(&value)
+            .deserialize_enum(name, variants, visitor)
+            .map_err(|err| DbError::SerdeError(err.to_string()))
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, DbError>
@@ -941,6 +991,24 @@ mod tests {
 
     #[test]
     fn test_serde_struct() {
+        #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+        struct UnitStruct;
+
+        #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+        enum TrivialEnum {
+            UnitStruct,
+        }
+
+        #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+        struct TrivialStruct {
+            foo: String,
+        }
+
+        #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+        struct NestedStruct {
+            bar: TrivialStruct,
+        }
+
         // Serializing and deserializing an arbitrary struct to a DbRow:
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct TestStruct {
@@ -963,6 +1031,10 @@ mod tests {
             text: String,
             text_opt: Option<String>,
             // biggerfloat: Decimal,
+            unit: UnitStruct,
+            enum_field: TrivialEnum,
+            struct_field: TrivialStruct,
+            nested_struct: NestedStruct,
         }
 
         let expected_struct = TestStruct {
@@ -985,6 +1057,16 @@ mod tests {
             text: 1.to_string(),
             text_opt: Some(1.to_string()),
             // biggerfloat: dec!(1),
+            unit: UnitStruct,
+            enum_field: TrivialEnum::UnitStruct,
+            struct_field: TrivialStruct {
+                foo: String::from("bar"),
+            },
+            nested_struct: NestedStruct {
+                bar: TrivialStruct {
+                    foo: String::from("bar"),
+                },
+            },
         };
 
         let expected_db_row = db_row! {
@@ -1007,12 +1089,24 @@ mod tests {
             "text" => "1",
             "text_opt" => "1",
             // "biggerfloat" => 1_i64,
+            "unit" => DbValue::Null,
+            "enum_field" => "\"UnitStruct\"",
+            "struct_field" => "{\"foo\":\"bar\"}",
+            "nested_struct" => "{\"bar\":{\"foo\":\"bar\"}}",
         };
-        assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
-        assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
+        assert_eq!(
+            expected_db_row,
+            to_db_row(&expected_struct).unwrap(),
+            "test serialize"
+        );
         assert_eq!(
             expected_struct,
-            from_db_row_indirect(&expected_db_row).unwrap()
+            from_db_row(&expected_db_row).unwrap(),
+            "test deserialize"
         );
+        // assert_eq!(
+        //     expected_struct,
+        //     from_db_row_indirect(&expected_db_row).unwrap()
+        // );
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,15 +1,9 @@
 use crate::{
     core::DbError,
-    db_value::{DbRow, DbValue},
+    db_value::{DbRow, DbValue, JsonRow, JsonValue},
 };
-use serde::{Serialize, ser};
-
-// TODO: Rename this to `Serializer` (or at least give it a better name).
-#[derive(Debug)]
-pub struct MySerializer {
-    keys: Vec<String>,
-    values: Vec<DbValue>,
-}
+use rust_decimal::prelude::ToPrimitive;
+use serde::{Deserialize, Serialize, ser};
 
 pub fn to_db_row<T>(value: &T) -> Result<DbRow, DbError>
 where
@@ -37,6 +31,55 @@ where
         db_row.insert(key.to_string(), values[i].clone());
     }
     Ok(db_row)
+}
+
+pub fn from_db_row<T>(db_row: &DbRow) -> Result<T, DbError>
+where
+    T: for<'a> Deserialize<'a>,
+{
+    // TODO: Can we do this directly without the intermediate step of first converting to JSON?
+    // The method below works and does not throw away information, so (unlike the case of
+    // serialization) we do not *need* to find an alternative method, but this seems inefficient
+    // and it would be better to deserialize directly from a DbRow to a T struct if possible.
+    let mut flat_json_row = JsonRow::new();
+    for (column, value) in db_row.iter() {
+        match value {
+            DbValue::Null => flat_json_row.insert(column.to_string(), JsonValue::Null),
+            DbValue::Boolean(num) => {
+                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
+            }
+            DbValue::SmallInteger(num) => {
+                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
+            }
+            DbValue::Integer(num) => {
+                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
+            }
+            DbValue::BigInteger(num) => {
+                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
+            }
+            DbValue::Real(num) => flat_json_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::BigReal(num) => {
+                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
+            }
+            DbValue::Numeric(num) => {
+                flat_json_row.insert(column.to_string(), JsonValue::from(num.to_f64()))
+            }
+            DbValue::Text(txt) => {
+                flat_json_row.insert(column.to_string(), JsonValue::from(txt.to_string()))
+            }
+        };
+    }
+    let flat_string_row = format!("{}", serde_json::json!(flat_json_row));
+    let t_struct: T = serde_json::from_str(&flat_string_row).unwrap();
+    Ok(t_struct)
+}
+
+// TODO: Maybe this doesn't need to be public.
+// TODO: Rename this to `Serializer` (or at least give it a better name).
+#[derive(Debug)]
+pub struct MySerializer {
+    keys: Vec<String>,
+    values: Vec<DbValue>,
 }
 
 impl<'a> ser::Serializer for &'a mut MySerializer {
@@ -352,12 +395,13 @@ impl<'a> ser::SerializeStructVariant for &'a mut MySerializer {
 mod tests {
     use super::*;
     use crate::{db_row, db_value::DbValue};
+    use serde::Deserialize;
     // use rust_decimal::{Decimal, dec};
 
     #[test]
     fn test_serde_struct() {
         // Serializing and deserializing an arbitrary struct to a DbRow:
-        #[derive(Serialize, PartialEq, Debug, Clone)]
+        #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct TestStruct {
             boolean: bool,
             smallint: i16,
@@ -391,13 +435,12 @@ mod tests {
             "text".into() => DbValue::from("1"),
         };
         assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
-        //assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
+        assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
 
-        // Serializing or deserializing a DbRow into a DbRow should yield a DbRow that is
-        // identical to the original one:
-        //let db_row = db_row! {"value".into() => DbValue::from("foo")};
-        //assert_eq!(db_row, to_db_row(&db_row).unwrap());
-        // TODO: Not yet working,
-        //assert_eq!(db_row, from_db_row(&db_row).unwrap());
+        // // Serializing or deserializing a DbRow into a DbRow should yield a DbRow that is
+        // // identical to the original one. TODO: This is not yet working.
+        // let db_row = db_row! {"value".into() => DbValue::from("foo")};
+        // assert_eq!(db_row, to_db_row(&db_row).unwrap());
+        // assert_eq!(db_row, from_db_row(&db_row).unwrap());
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,3 +1,5 @@
+//! Serialization / deserialization implementations for rltbl_db.
+
 use crate::{
     core::DbError,
     db_value::{DbRow, DbValue, JsonRow, JsonValue},
@@ -9,11 +11,30 @@ use serde::{
     ser,
 };
 
+////////////////////////////////////////////////////////////////////////////////
+// Serialization
+////////////////////////////////////////////////////////////////////////////////
+
+/// Convert the given struct to a [DbRow]. For this to be successful, the struct
+/// must be a "normal struct" of the form:
+///
+/// struct NormalStruct {
+///   field1: type1,
+///   field2: type2,
+///   ...
+/// }
+///
+/// where type1, type2, ... are among the primitive types associated with
+/// the different kinds of [DbValue]. Other field types, and other types of
+/// structs (e.g., tuple structs, unit structs, see
+/// <https://doc.rust-lang.org/book/ch05-01-defining-structs.html>) are not
+/// supported and attempts to serialize them will result in an error, as will
+/// attempts to serialize anything other than a struct (e.g., an enum).
 pub fn to_db_row<T>(value: &T) -> Result<DbRow, DbError>
 where
     T: Serialize,
 {
-    let mut serializer = MySerializer {
+    let mut serializer = DbRowSerializer {
         keys: vec![],
         values: vec![],
     };
@@ -37,66 +58,16 @@ where
     Ok(db_row)
 }
 
-pub fn from_db_row<T>(db_row: &DbRow) -> Result<T, DbError>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let mut deserializer = MyDeserializer::from_db_row(db_row);
-    let t = T::deserialize(&mut deserializer)?;
-    if deserializer.keys.is_empty() && deserializer.values.is_empty() {
-        Ok(t)
-    } else {
-        Err(DbError::SerdeError(
-            "Deserialization error: Leftover input".to_string(),
-        ))
-    }
-}
-
-// TODO: Remove this function before merging this branch. Keeping it around for now for comparison.
-pub fn from_db_row_indirect<T>(db_row: &DbRow) -> Result<T, DbError>
-where
-    T: for<'a> Deserialize<'a>,
-{
-    // The method below *works* and, unlike for serialization, where converting from JSON would
-    // necessarily throw away type information, converting to JSON in this case does not throw
-    // any type information away. So we do not *need* to find an alternative method. However this
-    // method (using the intermediate step of deserializing to JSON) seems inefficient
-    // and it is probably be better to deserialize directly from a DbRow to a T struct, as is done
-    // in from_db_row().
-    let mut flat_row = JsonRow::new();
-    for (column, value) in db_row.iter() {
-        match value {
-            DbValue::Null => flat_row.insert(column.to_string(), JsonValue::Null),
-            DbValue::Boolean(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::SmallInteger(num) => {
-                flat_row.insert(column.to_string(), JsonValue::from(*num))
-            }
-            DbValue::Integer(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::BigInteger(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::Real(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::BigReal(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::Numeric(num) => {
-                flat_row.insert(column.to_string(), JsonValue::from(num.to_f64()))
-            }
-            DbValue::Text(txt) => {
-                flat_row.insert(column.to_string(), JsonValue::from(txt.to_string()))
-            }
-        };
-    }
-    let t_struct: T = serde_json::from_str(&serde_json::json!(flat_row).to_string())
-        .map_err(|err| DbError::SerdeError(err.to_string()))?;
-    Ok(t_struct)
-}
-
-// TODO: Rename this to `Serializer` (or at least give it a better name).
 #[derive(Debug)]
-struct MySerializer {
+struct DbRowSerializer {
+    /// The keys of the output [DbRow].
     keys: Vec<String>,
+    /// The values of the output [DbRow].
     values: Vec<DbValue>,
 }
 
-impl<'a> ser::Serializer for &'a mut MySerializer {
-    // The output type produced by this `MySerializer` during successful
+impl<'a> ser::Serializer for &'a mut DbRowSerializer {
+    // The output type produced by this `DbRowSerializer` during successful
     // serialization.
     type Ok = ();
 
@@ -106,7 +77,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
     // Associated types for keeping track of additional state while serializing
     // compound data structures like sequences and maps. In this case no
     // additional state is required beyond what is already stored in the
-    // MySerializer struct.
+    // DbRowSerializer struct.
     type SerializeSeq = Self;
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
@@ -189,12 +160,14 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         ));
     }
 
+    // TODO: This should be supported.
     fn serialize_none(self) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
             "Serializing None is not supported".to_string(),
         ));
     }
 
+    // TODO: This should be supported.
     fn serialize_some<T>(self, _value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
@@ -285,7 +258,6 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         ));
     }
 
-    // Maps are represented in JSON as `{ K: V, K: V, ... }`.
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         Ok(self)
     }
@@ -311,31 +283,29 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
     }
 }
 
-impl<'a> ser::SerializeSeq for &'a mut MySerializer {
-    // Must match the `Ok` type of the serializer.
+impl<'a> ser::SerializeSeq for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
     type Ok = ();
-    // Must match the `Error` type of the serializer.
     type Error = DbError;
 
-    // Serialize a single element of the sequence.
     fn serialize_element<T>(&mut self, _value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "SerializeSeq::serialize_element() is not supported for MySerializer".to_string(),
+            "SerializeSeq::serialize_element() is not supported for DbRowSerializer".to_string(),
         ));
     }
 
-    // Close the sequence.
     fn end(self) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "SerializeSeq::end() is not supported for MySerializer".to_string(),
+            "SerializeSeq::end() is not supported for DbRowSerializer".to_string(),
         ));
     }
 }
 
-impl<'a> ser::SerializeTuple for &'a mut MySerializer {
+impl<'a> ser::SerializeTuple for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
     type Ok = ();
     type Error = DbError;
 
@@ -344,18 +314,19 @@ impl<'a> ser::SerializeTuple for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "SerializeTuple::serialize_element() is not supported for MySerializer".to_string(),
+            "SerializeTuple::serialize_element() is not supported for DbRowSerializer".to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "SerializeTuple::end() is not supported for MySerializer".to_string(),
+            "SerializeTuple::end() is not supported for DbRowSerializer".to_string(),
         ));
     }
 }
 
-impl<'a> ser::SerializeTupleStruct for &'a mut MySerializer {
+impl<'a> ser::SerializeTupleStruct for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
     type Ok = ();
     type Error = DbError;
 
@@ -364,39 +335,45 @@ impl<'a> ser::SerializeTupleStruct for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "SerializeTupleStruct::serialize_field() is not supported for MySerializer".to_string(),
-        ));
-    }
-
-    fn end(self) -> Result<(), DbError> {
-        return Err(DbError::SerdeError(
-            "SerializeTupleStruct::end() is not supported for MySerializer".to_string(),
-        ));
-    }
-}
-
-impl<'a> ser::SerializeTupleVariant for &'a mut MySerializer {
-    type Ok = ();
-    type Error = DbError;
-
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<(), DbError>
-    where
-        T: ?Sized + Serialize,
-    {
-        return Err(DbError::SerdeError(
-            "SerializeTupleVariant::serialize_field() is not supported for MySerializer"
+            "SerializeTupleStruct::serialize_field() is not supported for DbRowSerializer"
                 .to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "SerializeTupleVariant::end() is not supported for MySerializer".to_string(),
+            "SerializeTupleStruct::end() is not supported for DbRowSerializer".to_string(),
         ));
     }
 }
 
-impl<'a> ser::SerializeMap for &'a mut MySerializer {
+impl<'a> ser::SerializeTupleVariant for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_field<T>(&mut self, _value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        return Err(DbError::SerdeError(
+            "SerializeTupleVariant::serialize_field() is not supported for DbRowSerializer"
+                .to_string(),
+        ));
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        return Err(DbError::SerdeError(
+            "SerializeTupleVariant::end() is not supported for DbRowSerializer".to_string(),
+        ));
+    }
+}
+
+// Although a [DbRow] is essentially a wrapper around an IndexMap, when one is serialized,
+// the serialization begins with our implementation of SerializeStruct and does not require
+// us to explicitly implement working code for SerializeMap.
+impl<'a> ser::SerializeMap for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
     type Ok = ();
     type Error = DbError;
 
@@ -405,7 +382,7 @@ impl<'a> ser::SerializeMap for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "SerializeMap::serialize_key() is not supported for MySerializer".to_string(),
+            "SerializeMap::serialize_key() is not supported for DbRowSerializer".to_string(),
         ));
     }
 
@@ -414,18 +391,19 @@ impl<'a> ser::SerializeMap for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "SerializeMap::serialize_value() is not supported for MySerializer".to_string(),
+            "SerializeMap::serialize_value() is not supported for DbRowSerializer".to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "SerializeMap::end() is not supported for MySerializer".to_string(),
+            "SerializeMap::end() is not supported for DbRowSerializer".to_string(),
         ));
     }
 }
 
-impl<'a> ser::SerializeStruct for &'a mut MySerializer {
+impl<'a> ser::SerializeStruct for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
     type Ok = ();
     type Error = DbError;
 
@@ -443,7 +421,8 @@ impl<'a> ser::SerializeStruct for &'a mut MySerializer {
     }
 }
 
-impl<'a> ser::SerializeStructVariant for &'a mut MySerializer {
+impl<'a> ser::SerializeStructVariant for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
     type Ok = ();
     type Error = DbError;
 
@@ -452,60 +431,133 @@ impl<'a> ser::SerializeStructVariant for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "SerializeStructVariant::serialize_field() is not supported for MySerializer"
+            "SerializeStructVariant::serialize_field() is not supported for DbRowSerializer"
                 .to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "SerializeStructVariant::end() is not supported for MySerializer".to_string(),
+            "SerializeStructVariant::end() is not supported for DbRowSerializer".to_string(),
         ));
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Deserialization
+////////////////////////////////////////////////////////////////////////////////
+
+/// Convert the given [DbRow] to a supported struct. For this to be successful,
+/// the struct must be a "normal struct" of the form:
+///
+/// struct NormalStruct {
+///   field1: type1,
+///   field2: type2,
+///   ...
+/// }
+///
+/// where type1, type2, ... are among the primitive types associated with
+/// the different kinds of [DbValue]. Other field types, and other types of
+/// structs (e.g., tuple structs, unit structs, see
+/// <https://doc.rust-lang.org/book/ch05-01-defining-structs.html>) are not
+/// supported and attempts to deserialize a [DbRow] to them will result in an
+/// error, as will attempts to deserialize a [DbRow] to anything other than a
+/// struct (e.g., an enum).
+pub fn from_db_row<T>(db_row: &DbRow) -> Result<T, DbError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let mut deserializer = DbRowDeserializer::from_db_row(db_row);
+    let t = T::deserialize(&mut deserializer)?;
+    if deserializer.keys.is_empty() && deserializer.values.is_empty() {
+        Ok(t)
+    } else {
+        Err(DbError::SerdeError(
+            "Deserialization error: Leftover input".to_string(),
+        ))
+    }
+}
+
+// TODO: Remove this alternative implementation of from_db_row() before merging this branch.
+// Keeping it around for now for comparison with the preferred implementaion.
+pub fn from_db_row_indirect<T>(db_row: &DbRow) -> Result<T, DbError>
+where
+    T: for<'a> Deserialize<'a>,
+{
+    // The method below *works* and, unlike the case of serializing a struct to a DbRow, where
+    // converting to JSON as an intermediate step necessarily throws away the type information
+    // that we need for a successful serialization to DbRow, in the case of deserialization,
+    // converting to JSON as an intermediate step is not lossy in that sense. So we do not
+    // *need* to find an alternative method. However converting to JSON first seems
+    // inefficient and it is probably be better to deserialize directly from a DbRow
+    // to a T struct, as is done in from_db_row() above.
+    let mut flat_row = JsonRow::new();
+    for (column, value) in db_row.iter() {
+        match value {
+            DbValue::Null => flat_row.insert(column.to_string(), JsonValue::Null),
+            DbValue::Boolean(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::SmallInteger(num) => {
+                flat_row.insert(column.to_string(), JsonValue::from(*num))
+            }
+            DbValue::Integer(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::BigInteger(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::Real(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::BigReal(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::Numeric(num) => {
+                flat_row.insert(column.to_string(), JsonValue::from(num.to_f64()))
+            }
+            DbValue::Text(txt) => {
+                flat_row.insert(column.to_string(), JsonValue::from(txt.to_string()))
+            }
+        };
+    }
+    let t_struct: T = serde_json::from_str(&serde_json::json!(flat_row).to_string())
+        .map_err(|err| DbError::SerdeError(err.to_string()))?;
+    Ok(t_struct)
+}
+
 #[derive(Debug)]
-pub struct MyDeserializer<'de> {
+pub struct DbRowDeserializer<'de> {
+    /// The keys of the input [DbRow].
     keys: Vec<&'de str>,
+    /// The values of the input [DbRow].
     values: Vec<&'de DbValue>,
 }
 
-impl<'de> MyDeserializer<'de> {
+impl<'de> DbRowDeserializer<'de> {
     pub fn from_db_row(input: &'de DbRow) -> Self {
-        MyDeserializer {
+        DbRowDeserializer {
             keys: input.map.keys().map(|s| s.as_str()).collect::<Vec<_>>(),
             values: input.map.values().collect::<Vec<_>>(),
         }
     }
 
-    pub fn next_key(&mut self) -> Option<&'de str> {
+    pub fn pop_key(&mut self) -> Option<&'de str> {
         self.keys.pop()
     }
 
-    pub fn next_value(&mut self) -> Option<&'de DbValue> {
+    pub fn pop_value(&mut self) -> Option<&'de DbValue> {
         self.values.pop()
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
+impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     type Error = DbError;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // TODO: Change the unimplemented!() calls to actual errors, like we do for
-        // unsupported serializations above.
-        // println!("In deserialize_any()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'any' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_bool()");
-        let value = self.next_value().unwrap().as_bool().unwrap();
+        let value = self.pop_value().unwrap().as_bool().unwrap();
         visitor.visit_bool(value)
     }
 
@@ -513,16 +565,16 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_i8()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'i8' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_i16()");
-        let value = self.next_value().unwrap().as_i16().unwrap();
+        let value = self.pop_value().unwrap().as_i16().unwrap();
         visitor.visit_i16(value)
     }
 
@@ -530,8 +582,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_i32()");
-        let value = self.next_value().unwrap().as_i32().unwrap();
+        let value = self.pop_value().unwrap().as_i32().unwrap();
         visitor.visit_i32(value)
     }
 
@@ -539,8 +590,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_i64()");
-        let value = self.next_value().unwrap().as_i64().unwrap();
+        let value = self.pop_value().unwrap().as_i64().unwrap();
         visitor.visit_i64(value)
     }
 
@@ -548,40 +598,43 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_u8()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'u8' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_u16()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'u16' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_u32()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'u32' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_u64()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'u64' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_f32()");
-        let value = self.next_value().unwrap().as_f32().unwrap();
+        let value = self.pop_value().unwrap().as_f32().unwrap();
         visitor.visit_f32(value)
     }
 
@@ -589,8 +642,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_f64()");
-        let value = self.next_value().unwrap().as_f64().unwrap();
+        let value = self.pop_value().unwrap().as_f64().unwrap();
         visitor.visit_f64(value)
     }
 
@@ -598,24 +650,25 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_char()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'char' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_string()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'str' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_string()");
-        let value = self.next_value().unwrap().as_str().unwrap();
+        let value = self.pop_value().unwrap().as_str().unwrap();
         visitor.visit_borrowed_str(value)
     }
 
@@ -623,18 +676,21 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_bytes()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'bytes' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_byte_buf()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'byte_buf' is not supported".to_string(),
+        ));
     }
 
+    // TODO: We should probably support this.
     fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
@@ -647,8 +703,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_unit()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'unit' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_unit_struct<V>(
@@ -659,8 +716,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_unit_struct()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'unit_struct' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_newtype_struct<V>(
@@ -671,24 +729,27 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_newtype_struct()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'newtype_struct' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_seq()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'seq' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_tuple()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'tuple' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_tuple_struct<V>(
@@ -700,15 +761,15 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_tuple_struct()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'tuple_struct' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_map()");
         let value = visitor.visit_map(self)?;
         Ok(value)
     }
@@ -722,7 +783,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_struct()");
         self.deserialize_map(visitor)
     }
 
@@ -735,8 +795,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_enum()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'enum' is not supported".to_string(),
+        ));
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DbError>
@@ -744,8 +805,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
         V: Visitor<'de>,
     {
         // TODO: Remove unwraps here and elsewhere.
-        // println!("In deserialize_identifier()");
-        let key = self.next_key().unwrap();
+        let key = self.pop_key().unwrap();
         visitor.visit_borrowed_str(key)
     }
 
@@ -753,19 +813,19 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_ignored_any()");
-        unimplemented!()
+        return Err(DbError::SerdeError(
+            "Deserializing 'ignored_any' is not supported".to_string(),
+        ));
     }
 }
 
-impl<'de> de::MapAccess<'de> for MyDeserializer<'de> {
+impl<'de> de::MapAccess<'de> for DbRowDeserializer<'de> {
     type Error = DbError;
 
     fn next_key_seed<S>(&mut self, seed: S) -> Result<Option<S::Value>, Self::Error>
     where
         S: de::DeserializeSeed<'de>,
     {
-        // println!("In next_key_seed() with SELF: {self:?}");
         if self.keys.len() == 0 {
             return Ok(None);
         }
@@ -776,7 +836,6 @@ impl<'de> de::MapAccess<'de> for MyDeserializer<'de> {
     where
         S: de::DeserializeSeed<'de>,
     {
-        // println!("In next_value_seed() with SELF: {self:?}");
         seed.deserialize(&mut *self)
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -160,27 +160,20 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
         ));
     }
 
-    // TODO: This should be supported.
     fn serialize_none(self) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing None is not supported".to_string(),
-        ));
+        self.serialize_unit()
     }
 
-    // TODO: This should be supported.
-    fn serialize_some<T>(self, _value: &T) -> Result<(), Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        return Err(DbError::SerdeError(
-            "Serializing Some is not supported".to_string(),
-        ));
+        value.serialize(self)
     }
 
     fn serialize_unit(self) -> Result<(), Self::Error> {
-        return Err(DbError::SerdeError(
-            "Serializing unit is not supported".to_string(),
-        ));
+        self.values.push(DbValue::Null);
+        Ok(())
     }
 
     fn serialize_unit_struct(self, _name: &str) -> Result<(), Self::Error> {
@@ -557,8 +550,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let value = self.pop_value().unwrap().as_bool().unwrap();
-        visitor.visit_bool(value)
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_bool().unwrap();
+                visitor.visit_bool(value)
+            }
+        }
     }
 
     fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, DbError>
@@ -574,24 +573,42 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let value = self.pop_value().unwrap().as_i16().unwrap();
-        visitor.visit_i16(value)
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_i16().unwrap();
+                visitor.visit_i16(value)
+            }
+        }
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        let value = self.pop_value().unwrap().as_i32().unwrap();
-        visitor.visit_i32(value)
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_i32().unwrap();
+                visitor.visit_i32(value)
+            }
+        }
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        let value = self.pop_value().unwrap().as_i64().unwrap();
-        visitor.visit_i64(value)
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_i64().unwrap();
+                visitor.visit_i64(value)
+            }
+        }
     }
 
     fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, DbError>
@@ -634,16 +651,28 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let value = self.pop_value().unwrap().as_f32().unwrap();
-        visitor.visit_f32(value)
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_f32().unwrap();
+                visitor.visit_f32(value)
+            }
+        }
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        let value = self.pop_value().unwrap().as_f64().unwrap();
-        visitor.visit_f64(value)
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_f64().unwrap();
+                visitor.visit_f64(value)
+            }
+        }
     }
 
     fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, DbError>
@@ -668,8 +697,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let value = self.pop_value().unwrap().as_str().unwrap();
-        visitor.visit_borrowed_str(value)
+        match self.values.last().unwrap() {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => {
+                let value = self.pop_value().unwrap();
+                let value = value.as_str().unwrap();
+                visitor.visit_borrowed_str(value)
+            }
+        }
     }
 
     fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DbError>
@@ -690,22 +725,25 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         ));
     }
 
-    // TODO: We should probably support this.
-    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        // println!("In deserialize_option()");
-        unimplemented!()
+        let value = self.values.last().unwrap();
+        match value {
+            DbValue::Null => self.deserialize_unit(visitor),
+            _ => visitor.visit_some(self),
+        }
     }
 
-    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, DbError>
     where
         V: Visitor<'de>,
     {
-        return Err(DbError::SerdeError(
-            "Deserializing 'unit' is not supported".to_string(),
-        ));
+        let value = self.pop_value().unwrap();
+        // TODO: Remove the assert
+        assert_eq!(*value, DbValue::Null);
+        visitor.visit_unit()
     }
 
     fn deserialize_unit_struct<V>(
@@ -853,41 +891,62 @@ mod tests {
         #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
         struct TestStruct {
             boolean: bool,
+            boolean_opt: Option<bool>,
             smallint: i16,
+            smallint_opt: Option<i16>,
             mediumint: i32,
+            mediumint_opt: Option<i32>,
             bigint: i64,
+            bigint_opt: Option<i64>,
             smallfloat: f32,
+            smallfloat_opt: Option<f32>,
             bigfloat: f64,
+            bigfloat_opt: Option<f64>,
             // biggerfloat: Decimal,
             text: String,
+            text_opt: Option<String>,
         }
 
         let expected_struct = TestStruct {
             boolean: true,
+            boolean_opt: Some(true),
             smallint: 1,
+            smallint_opt: None,
             mediumint: 1,
+            mediumint_opt: Some(1),
             bigint: 1,
+            bigint_opt: None,
             smallfloat: 1_f32,
+            smallfloat_opt: Some(1_f32),
             bigfloat: 1_f64,
+            bigfloat_opt: None,
             // biggerfloat: dec!(1),
             text: 1.to_string(),
+            text_opt: Some(1.to_string()),
         };
 
         let expected_db_row = db_row! {
             "boolean".into() => DbValue::from(true),
+            "boolean_opt".into() => DbValue::from(true),
             "smallint".into() => DbValue::from(1_i16),
+            "smallint_opt".into() => DbValue::Null,
             "mediumint".into() => DbValue::from(1_i32),
+            "mediumint_opt".into() => DbValue::from(1_i32),
             "bigint".into() => DbValue::from(1_i64),
+            "bigint_opt".into() => DbValue::Null,
             "smallfloat".into() => DbValue::from(1_f32),
+            "smallfloat_opt".into() => DbValue::from(1_f32),
             "bigfloat".into() => DbValue::from(1_f64),
+            "bigfloat_opt".into() => DbValue::Null,
             // "biggerfloat".into() => DbValue::from(1_i64),
             "text".into() => DbValue::from("1"),
+            "text_opt".into() => DbValue::from("1"),
         };
         assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
         assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
-        assert_eq!(
-            expected_struct,
-            from_db_row_indirect(&expected_db_row).unwrap()
-        );
+        //assert_eq!(
+        //    expected_struct,
+        //    from_db_row_indirect(&expected_db_row).unwrap()
+        //);
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -669,8 +669,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = self.pop_value().unwrap();
-        // TODO: Remove the assert
-        assert_eq!(*value, DbValue::Null);
+        if *value != DbValue::Null {
+            return Err(DbError::SerdeError("Expected NULL".to_string()));
+        }
         visitor.visit_unit()
     }
 
@@ -947,21 +948,21 @@ mod tests {
         };
 
         let expected_db_row = db_row! {
-            "boolean".into() => DbValue::from(true),
-            "boolean_opt".into() => DbValue::from(true),
-            "smallint".into() => DbValue::from(1_i16),
-            "smallint_opt".into() => DbValue::Null,
-            "mediumint".into() => DbValue::from(1_i32),
-            "mediumint_opt".into() => DbValue::from(1_i32),
-            "bigint".into() => DbValue::from(1_i64),
-            "bigint_opt".into() => DbValue::Null,
-            "smallfloat".into() => DbValue::from(1_f32),
-            "smallfloat_opt".into() => DbValue::from(1_f32),
-            "bigfloat".into() => DbValue::from(1_f64),
-            "bigfloat_opt".into() => DbValue::Null,
-            // "biggerfloat".into() => DbValue::from(1_i64),
-            "text".into() => DbValue::from("1"),
-            "text_opt".into() => DbValue::from("1"),
+            "boolean" => true,
+            "boolean_opt" => true,
+            "smallint" => 1_i16,
+            "smallint_opt" => DbValue::Null,
+            "mediumint" => 1_i32,
+            "mediumint_opt" => 1_i32,
+            "bigint" => 1_i64,
+            "bigint_opt" => DbValue::Null,
+            "smallfloat" => 1_f32,
+            "smallfloat_opt" => 1_f32,
+            "bigfloat" => 1_f64,
+            "bigfloat_opt" => DbValue::Null,
+            // "biggerfloat" => 1_i64,
+            "text" => "1",
+            "text_opt" => "1",
         };
         assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
         assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -38,46 +38,40 @@ where
     T: for<'a> Deserialize<'a>,
 {
     // TODO: Can we do this directly without the intermediate step of first converting to JSON?
-    // The method below works and does not throw away information, so (unlike the case of
-    // serialization) we do not *need* to find an alternative method, but this seems inefficient
-    // and it would be better to deserialize directly from a DbRow to a T struct if possible.
-    let mut flat_json_row = JsonRow::new();
+    // The method below *works* and, unlike for serialization, where converting from JSON would
+    // necessarily throw away type information, converting to JSON in this case does not throw
+    // any type information away. So we do not *need* to find an alternative method. However this
+    // method (using the intermediate step of deserializing to JSON) seems inefficient
+    // and it would probably be better to deserialize directly from a DbRow to a T struct if
+    // possible.
+    let mut flat_row = JsonRow::new();
     for (column, value) in db_row.iter() {
         match value {
-            DbValue::Null => flat_json_row.insert(column.to_string(), JsonValue::Null),
-            DbValue::Boolean(num) => {
-                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
-            }
+            DbValue::Null => flat_row.insert(column.to_string(), JsonValue::Null),
+            DbValue::Boolean(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
             DbValue::SmallInteger(num) => {
-                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
+                flat_row.insert(column.to_string(), JsonValue::from(*num))
             }
-            DbValue::Integer(num) => {
-                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
-            }
-            DbValue::BigInteger(num) => {
-                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
-            }
-            DbValue::Real(num) => flat_json_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::BigReal(num) => {
-                flat_json_row.insert(column.to_string(), JsonValue::from(*num))
-            }
+            DbValue::Integer(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::BigInteger(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::Real(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::BigReal(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
             DbValue::Numeric(num) => {
-                flat_json_row.insert(column.to_string(), JsonValue::from(num.to_f64()))
+                flat_row.insert(column.to_string(), JsonValue::from(num.to_f64()))
             }
             DbValue::Text(txt) => {
-                flat_json_row.insert(column.to_string(), JsonValue::from(txt.to_string()))
+                flat_row.insert(column.to_string(), JsonValue::from(txt.to_string()))
             }
         };
     }
-    let flat_string_row = format!("{}", serde_json::json!(flat_json_row));
-    let t_struct: T = serde_json::from_str(&flat_string_row).unwrap();
+    let t_struct: T = serde_json::from_str(&serde_json::json!(flat_row).to_string())
+        .map_err(|err| DbError::SerdeError(err.to_string()))?;
     Ok(t_struct)
 }
 
-// TODO: Maybe this doesn't need to be public.
 // TODO: Rename this to `Serializer` (or at least give it a better name).
 #[derive(Debug)]
-pub struct MySerializer {
+struct MySerializer {
     keys: Vec<String>,
     values: Vec<DbValue>,
 }
@@ -108,7 +102,9 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
     }
 
     fn serialize_i8(self, _value: i8) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize an i8".to_string(),
+        ));
     }
 
     fn serialize_i16(self, value: i16) -> Result<(), Self::Error> {
@@ -127,7 +123,9 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
     }
 
     fn serialize_u8(self, _value: u8) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a u8".to_string(),
+        ));
     }
 
     fn serialize_u16(self, value: u16) -> Result<(), Self::Error> {
@@ -156,7 +154,9 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
     }
 
     fn serialize_char(self, _value: char) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a char".to_string(),
+        ));
     }
 
     fn serialize_str(self, value: &str) -> Result<(), Self::Error> {
@@ -165,26 +165,36 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
     }
 
     fn serialize_bytes(self, _values: &[u8]) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize bytes to a DbValue".to_string(),
+        ));
     }
 
     fn serialize_none(self) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize None".to_string(),
+        ));
     }
 
     fn serialize_some<T>(self, _value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize Some".to_string(),
+        ));
     }
 
     fn serialize_unit(self) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a unit".to_string(),
+        ));
     }
 
     fn serialize_unit_struct(self, _name: &str) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a unit struct".to_string(),
+        ));
     }
 
     fn serialize_unit_variant(
@@ -193,14 +203,18 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         _variant_index: u32,
         _variant: &str,
     ) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a unit variant".to_string(),
+        ));
     }
 
     fn serialize_newtype_struct<T>(self, _name: &str, _value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a newtype struct".to_string(),
+        ));
     }
 
     fn serialize_newtype_variant<T>(
@@ -213,15 +227,21 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a newtype variant".to_string(),
+        ));
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a seq".to_string(),
+        ));
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a tuple".to_string(),
+        ));
     }
 
     fn serialize_tuple_struct(
@@ -229,7 +249,9 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         _name: &str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a tuple struct".to_string(),
+        ));
     }
 
     fn serialize_tuple_variant(
@@ -239,7 +261,9 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         _variant: &str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a tuple variant".to_string(),
+        ));
     }
 
     // Maps are represented in JSON as `{ K: V, K: V, ... }`.
@@ -262,7 +286,9 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         _variant: &str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to serialize a struct variant".to_string(),
+        ));
     }
 }
 
@@ -277,12 +303,16 @@ impl<'a> ser::SerializeSeq for &'a mut MySerializer {
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeSeq for MySerializer".to_string(),
+        ));
     }
 
     // Close the sequence.
     fn end(self) -> Result<(), Self::Error> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeSeq for MySerializer".to_string(),
+        ));
     }
 }
 
@@ -294,11 +324,15 @@ impl<'a> ser::SerializeTuple for &'a mut MySerializer {
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeTuple for MySerializer".to_string(),
+        ));
     }
 
     fn end(self) -> Result<(), DbError> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeTuple for MySerializer".to_string(),
+        ));
     }
 }
 
@@ -310,11 +344,15 @@ impl<'a> ser::SerializeTupleStruct for &'a mut MySerializer {
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeTupleStruct for MySerializer".to_string(),
+        ));
     }
 
     fn end(self) -> Result<(), DbError> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeTupleStruct for MySerializer".to_string(),
+        ));
     }
 }
 
@@ -326,11 +364,15 @@ impl<'a> ser::SerializeTupleVariant for &'a mut MySerializer {
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeTupleVariant for MySerializer".to_string(),
+        ));
     }
 
     fn end(self) -> Result<(), DbError> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeTupleVariant for MySerializer".to_string(),
+        ));
     }
 }
 
@@ -342,18 +384,24 @@ impl<'a> ser::SerializeMap for &'a mut MySerializer {
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeMap for MySerializer".to_string(),
+        ));
     }
 
     fn serialize_value<T>(&mut self, _value: &T) -> Result<(), DbError>
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeMap for MySerializer".to_string(),
+        ));
     }
 
     fn end(self) -> Result<(), DbError> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeMap for MySerializer".to_string(),
+        ));
     }
 }
 
@@ -383,11 +431,15 @@ impl<'a> ser::SerializeStructVariant for &'a mut MySerializer {
     where
         T: ?Sized + Serialize,
     {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeStructVariant for MySerializer".to_string(),
+        ));
     }
 
     fn end(self) -> Result<(), DbError> {
-        todo!()
+        return Err(DbError::SerdeError(
+            "I don't know how to implement SerializeStructVariant for MySerializer".to_string(),
+        ));
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,120 +1,47 @@
 use crate::{
     core::DbError,
-    db_value::{DbRow, DbValue, JsonRow, JsonValue},
+    db_value::{DbRow, DbValue},
 };
-use rust_decimal::Decimal;
-use serde::{
-    Deserialize, Serialize,
-    de::{
-        self, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, VariantAccess,
-        Visitor,
-    },
-    ser::{self, SerializeSeq as _},
-};
-use std::{
-    ops::{AddAssign, MulAssign, Neg},
-    str::FromStr,
-};
+use serde::{Serialize, ser};
 
-// TODO: Most of the comments and docstrings below were copied (initially) verbatim from
-// https://serde.rs/impl-serializer.html. After we adapt that template to our use case these
-// need to be updated.
-
-/// Used for serialization / deserialization of a [DbRow] to/from a struct
-pub struct Serializer {
-    output_old_remove_me: String,
-    _output_new_not_used_yet: DbRow,
-}
-
-// By convention, the public API of a Serde serializer is one or more `to_abc`
-// functions such as `to_string`, `to_bytes`, or `to_writer` depending on what
-// Rust types the serializer is able to produce as output.
-//
-
-pub fn to_string<T>(value: &T) -> Result<String, DbError>
-where
-    T: Serialize,
-{
-    let mut serializer = Serializer {
-        output_old_remove_me: String::new(),
-        _output_new_not_used_yet: DbRow::new(),
-    };
-    value.serialize(&mut serializer)?;
-    Ok(serializer.output_old_remove_me)
+// TODO: Rename this to `Serializer` (or at least give it a better name).
+#[derive(Debug)]
+pub struct MySerializer {
+    keys: Vec<String>,
+    values: Vec<DbValue>,
 }
 
 pub fn to_db_row<T>(value: &T) -> Result<DbRow, DbError>
 where
     T: Serialize,
 {
-    // TODO: This is a very inefficient way of serializing a struct to a DbRow, but it works.
-    // We need to eliminate the dependency on serde_json and serialize directly to a DbRow
-    // rather than first to a string. We might be able to use "type OK = TYPE" (see below)
-    // to help with this.
-
-    let value_string = to_string(value)?;
-    //println!("VALUE STRING: {value_string}");
+    let mut serializer = MySerializer {
+        keys: vec![],
+        values: vec![],
+    };
+    value.serialize(&mut serializer)?;
+    let keys = serializer.keys;
+    let values = serializer.values;
+    if keys.len() != values.len() {
+        return Err(DbError::SerdeError(format!(
+            "Keys and values have different lengths: \
+             Keys: {keys:?} (length: {klen}), \
+             Values: {values:?} (length: {vlen})",
+            klen = keys.len(),
+            vlen = values.len(),
+        )));
+    }
 
     let mut db_row = DbRow::new();
-    let json_row = serde_json::from_str::<JsonValue>(&value_string).unwrap();
-    let json_row = json_row.as_object().unwrap();
-    for (column, value) in json_row.iter() {
-        //println!("VALUE: {value:?}");
-        match value.as_object() {
-            Some(value) => {
-                assert_eq!(value.len(), 1);
-                let value = value.iter().collect::<Vec<_>>()[0];
-                let value_type = value.0;
-                match value_type.to_lowercase().as_str() {
-                    "null" => db_row.insert(column.to_string(), DbValue::Null),
-                    "boolean" => db_row.insert(
-                        column.to_string(),
-                        DbValue::Boolean(value.1.as_bool().unwrap()),
-                    ),
-                    "smallinteger" => db_row.insert(
-                        column.to_string(),
-                        DbValue::SmallInteger(value.1.as_i64().unwrap().try_into().unwrap()),
-                    ),
-                    "integer" => db_row.insert(
-                        column.to_string(),
-                        DbValue::Integer(value.1.as_i64().unwrap().try_into().unwrap()),
-                    ),
-                    "biginteger" => db_row.insert(
-                        column.to_string(),
-                        DbValue::BigInteger(value.1.as_i64().unwrap()),
-                    ),
-                    "real" => db_row.insert(
-                        column.to_string(),
-                        DbValue::Real(value.1.as_f64().unwrap() as f32),
-                    ),
-                    "bigreal" => db_row.insert(
-                        column.to_string(),
-                        DbValue::BigReal(value.1.as_f64().unwrap()),
-                    ),
-                    "numeric" => db_row.insert(
-                        column.to_string(),
-                        DbValue::Numeric(Decimal::from_str(&value.1.to_string()).unwrap()),
-                    ),
-                    "text" => db_row.insert(
-                        column.to_string(),
-                        DbValue::Text(value.1.as_str().unwrap().to_string()),
-                    ),
-                    _ => panic!(),
-                }
-            }
-            None => db_row.insert(column.to_string(), DbValue::from(value.clone())),
-        }
+    for (i, key) in keys.iter().enumerate() {
+        db_row.insert(key.to_string(), values[i].clone());
     }
     Ok(db_row)
 }
 
-impl<'a> ser::Serializer for &'a mut Serializer {
-    // The output type produced by this `Serializer` during successful
-    // serialization. Most serializers that produce text or binary output should
-    // set `Ok = ()` and serialize into an `io::Write` or buffer contained
-    // within the `Serializer` instance, as happens here. Serializers that build
-    // in-memory data structures may be simplified by using `Ok` to propagate
-    // the data structure around.
+impl<'a> ser::Serializer for &'a mut MySerializer {
+    // The output type produced by this `MySerializer` during successful
+    // serialization.
     type Ok = ();
 
     // The error type when some error occurs during serialization.
@@ -123,7 +50,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     // Associated types for keeping track of additional state while serializing
     // compound data structures like sequences and maps. In this case no
     // additional state is required beyond what is already stored in the
-    // Serializer struct.
+    // MySerializer struct.
     type SerializeSeq = Self;
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
@@ -132,229 +59,151 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     type SerializeStruct = Self;
     type SerializeStructVariant = Self;
 
-    // Here we go with the simple methods. The following 12 methods receive one
-    // of the primitive types of the data model and map it to JSON by appending
-    // into the output string.
-
     fn serialize_bool(self, value: bool) -> Result<(), Self::Error> {
-        self.output_old_remove_me += match value {
-            true => "true",
-            false => "false",
-        };
+        self.values.push(DbValue::from(value));
         Ok(())
     }
 
-    // JSON does not distinguish between different sizes of integers, so all
-    // signed integers will be serialized the same and all unsigned integers
-    // will be serialized the same. Other formats, especially compact binary
-    // formats, may need independent logic for the different sizes.
-
-    fn serialize_i8(self, value: i8) -> Result<(), Self::Error> {
-        self.serialize_i64(i64::from(value))
+    fn serialize_i8(self, _value: i8) -> Result<(), Self::Error> {
+        todo!()
     }
 
     fn serialize_i16(self, value: i16) -> Result<(), Self::Error> {
-        self.serialize_i64(i64::from(value))
-    }
-
-    fn serialize_i32(self, value: i32) -> Result<(), Self::Error> {
-        self.serialize_i64(i64::from(value))
-    }
-
-    // Not particularly efficient but this is example code anyway. A more
-    // performant approach would be to use the `itoa` crate.
-    fn serialize_i64(self, value: i64) -> Result<(), Self::Error> {
-        self.output_old_remove_me += &value.to_string();
+        self.values.push(DbValue::from(value));
         Ok(())
     }
 
-    fn serialize_u8(self, value: u8) -> Result<(), Self::Error> {
-        self.serialize_u64(u64::from(value))
+    fn serialize_i32(self, value: i32) -> Result<(), Self::Error> {
+        self.values.push(DbValue::from(value));
+        Ok(())
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<(), Self::Error> {
+        self.values.push(DbValue::from(value));
+        Ok(())
+    }
+
+    fn serialize_u8(self, _value: u8) -> Result<(), Self::Error> {
+        todo!()
     }
 
     fn serialize_u16(self, value: u16) -> Result<(), Self::Error> {
-        self.serialize_u64(u64::from(value))
+        self.values.push(DbValue::from(value));
+        Ok(())
     }
 
     fn serialize_u32(self, value: u32) -> Result<(), Self::Error> {
-        self.serialize_u64(u64::from(value))
+        self.values.push(DbValue::from(value));
+        Ok(())
     }
 
     fn serialize_u64(self, value: u64) -> Result<(), Self::Error> {
-        self.output_old_remove_me += &value.to_string();
+        self.values.push(DbValue::from(value));
         Ok(())
     }
 
     fn serialize_f32(self, value: f32) -> Result<(), Self::Error> {
-        self.serialize_f64(f64::from(value))
+        self.values.push(DbValue::from(value));
+        Ok(())
     }
 
     fn serialize_f64(self, value: f64) -> Result<(), Self::Error> {
-        self.output_old_remove_me += &value.to_string();
+        self.values.push(DbValue::from(value));
         Ok(())
     }
 
-    // Serialize a char as a single-character string. Other formats may
-    // represent this differently.
-    fn serialize_char(self, value: char) -> Result<(), Self::Error> {
-        self.serialize_str(&value.to_string())
+    fn serialize_char(self, _value: char) -> Result<(), Self::Error> {
+        todo!()
     }
 
-    // This only works for strings that don't require escape sequences but you
-    // get the idea. For example it would emit invalid JSON if the input string
-    // contains a '"' character.
     fn serialize_str(self, value: &str) -> Result<(), Self::Error> {
-        self.output_old_remove_me += "\"";
-        self.output_old_remove_me += value;
-        self.output_old_remove_me += "\"";
+        self.values.push(DbValue::from(value));
         Ok(())
     }
 
-    // Serialize a byte array as an array of bytes. Could also use a base64
-    // string here. Binary formats will typically represent byte arrays more
-    // compactly.
-    fn serialize_bytes(self, values: &[u8]) -> Result<(), Self::Error> {
-        let mut seq = self.serialize_seq(Some(values.len()))?;
-        for byte in values {
-            seq.serialize_element(byte)?;
-        }
-        seq.end()
+    fn serialize_bytes(self, _values: &[u8]) -> Result<(), Self::Error> {
+        todo!()
     }
 
-    // An absent optional is represented as the JSON `null`.
     fn serialize_none(self) -> Result<(), Self::Error> {
-        self.serialize_unit()
+        todo!()
     }
 
-    // A present optional is represented as just the contained value. Note that
-    // this is a lossy representation. For example the values `Some(())` and
-    // `None` both serialize as just `null`. Unfortunately this is typically
-    // what people expect when working with JSON. Other formats are encouraged
-    // to behave more intelligently if possible.
-    fn serialize_some<T>(self, value: &T) -> Result<(), Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(self)
+        todo!()
     }
 
-    // In Serde, unit means an anonymous value containing no data. Map this to
-    // JSON as `null`.
     fn serialize_unit(self) -> Result<(), Self::Error> {
-        self.output_old_remove_me += "null";
-        Ok(())
+        todo!()
     }
 
-    // Unit struct means a named value containing no data. Again, since there is
-    // no data, map this to JSON as `null`. There is no need to serialize the
-    // name in most formats.
     fn serialize_unit_struct(self, _name: &str) -> Result<(), Self::Error> {
-        self.serialize_unit()
+        todo!()
     }
 
-    // When serializing a unit variant (or any other kind of variant), formats
-    // can choose whether to keep track of it by index or by name. Binary
-    // formats typically use the index of the variant and human-readable formats
-    // typically use the name.
     fn serialize_unit_variant(
         self,
         _name: &str,
         _variant_index: u32,
-        variant: &str,
+        _variant: &str,
     ) -> Result<(), Self::Error> {
-        self.serialize_str(variant)
+        todo!()
     }
 
-    // As is done here, serializers are encouraged to treat newtype structs as
-    // insignificant wrappers around the data they contain.
-    fn serialize_newtype_struct<T>(self, _name: &str, value: &T) -> Result<(), Self::Error>
+    fn serialize_newtype_struct<T>(self, _name: &str, _value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(self)
+        todo!()
     }
 
-    // Note that newtype variant (and all of the other variant serialization
-    // methods) refer exclusively to the "externally tagged" enum
-    // representation.
-    //
-    // Serialize this to JSON in externally tagged form as `{ NAME: VALUE }`.
     fn serialize_newtype_variant<T>(
         self,
         _name: &str,
         _variant_index: u32,
-        variant: &str,
-        value: &T,
+        _variant: &str,
+        _value: &T,
     ) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        self.output_old_remove_me += "{";
-        variant.serialize(&mut *self)?;
-        self.output_old_remove_me += ":";
-        value.serialize(&mut *self)?;
-        self.output_old_remove_me += "}";
-        Ok(())
+        todo!()
     }
 
-    // Now we get to the serialization of compound types.
-    //
-    // The start of the sequence, each value, and the end are three separate
-    // method calls. This one is responsible only for serializing the start,
-    // which in JSON is `[`.
-    //
-    // The length of the sequence may or may not be known ahead of time. This
-    // doesn't make a difference in JSON because the length is not represented
-    // explicitly in the serialized form. Some serializers may only be able to
-    // support sequences for which the length is known up front.
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        self.output_old_remove_me += "[";
-        Ok(self)
+        todo!()
     }
 
-    // Tuples look just like sequences in JSON. Some formats may be able to
-    // represent tuples more efficiently by omitting the length, since tuple
-    // means that the corresponding `Deserialize implementation will know the
-    // length without needing to look at the serialized data.
-    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        self.serialize_seq(Some(len))
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        todo!()
     }
 
-    // Tuple structs look just like sequences in JSON.
     fn serialize_tuple_struct(
         self,
         _name: &str,
-        len: usize,
+        _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        self.serialize_seq(Some(len))
+        todo!()
     }
 
-    // Tuple variants are represented in JSON as `{ NAME: [DATA...] }`. Again
-    // this method is only responsible for the externally tagged representation.
     fn serialize_tuple_variant(
         self,
         _name: &str,
         _variant_index: u32,
-        variant: &str,
+        _variant: &str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        self.output_old_remove_me += "{";
-        variant.serialize(&mut *self)?;
-        self.output_old_remove_me += ":[";
-        Ok(self)
+        todo!()
     }
 
     // Maps are represented in JSON as `{ K: V, K: V, ... }`.
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        self.output_old_remove_me += "{";
         Ok(self)
     }
 
-    // Structs look just like maps in JSON. In particular, JSON requires that we
-    // serialize the field names of the struct. Other formats may be able to
-    // omit the field names when serializing structs because the corresponding
-    // Deserialize implementation is required to know what the keys are without
-    // looking at the serialized data.
     fn serialize_struct(
         self,
         _name: &str,
@@ -363,175 +212,109 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.serialize_map(Some(len))
     }
 
-    // Struct variants are represented in JSON as `{ NAME: { K: V, ... } }`.
-    // This is the externally tagged representation.
     fn serialize_struct_variant(
         self,
         _name: &str,
         _variant_index: u32,
-        variant: &str,
+        _variant: &str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        self.output_old_remove_me += "{";
-        variant.serialize(&mut *self)?;
-        self.output_old_remove_me += ":{";
-        Ok(self)
+        todo!()
     }
 }
 
-// The following 7 impls deal with the serialization of compound types like
-// sequences and maps. Serialization of such types is begun by a Serializer
-// method and followed by zero or more calls to serialize individual elements of
-// the compound type and one call to end the compound type.
-//
-// This impl is SerializeSeq so these methods are called after `serialize_seq`
-// is called on the Serializer.
-
-impl<'a> ser::SerializeSeq for &'a mut Serializer {
+impl<'a> ser::SerializeSeq for &'a mut MySerializer {
     // Must match the `Ok` type of the serializer.
     type Ok = ();
     // Must match the `Error` type of the serializer.
     type Error = DbError;
 
     // Serialize a single element of the sequence.
-    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, _value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        if !self.output_old_remove_me.ends_with('[') {
-            self.output_old_remove_me += ",";
-        }
-        value.serialize(&mut **self)
+        todo!()
     }
 
     // Close the sequence.
     fn end(self) -> Result<(), Self::Error> {
-        self.output_old_remove_me += "]";
-        Ok(())
+        todo!()
     }
 }
 
-// Same thing but for tuples.
-impl<'a> ser::SerializeTuple for &'a mut Serializer {
+impl<'a> ser::SerializeTuple for &'a mut MySerializer {
     type Ok = ();
     type Error = DbError;
 
-    fn serialize_element<T>(&mut self, value: &T) -> Result<(), DbError>
+    fn serialize_element<T>(&mut self, _value: &T) -> Result<(), DbError>
     where
         T: ?Sized + Serialize,
     {
-        if !self.output_old_remove_me.ends_with('[') {
-            self.output_old_remove_me += ",";
-        }
-        value.serialize(&mut **self)
+        todo!()
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output_old_remove_me += "]";
-        Ok(())
+        todo!()
     }
 }
 
-// Same thing but for tuple structs.
-impl<'a> ser::SerializeTupleStruct for &'a mut Serializer {
+impl<'a> ser::SerializeTupleStruct for &'a mut MySerializer {
     type Ok = ();
     type Error = DbError;
 
-    fn serialize_field<T>(&mut self, value: &T) -> Result<(), DbError>
+    fn serialize_field<T>(&mut self, _value: &T) -> Result<(), DbError>
     where
         T: ?Sized + Serialize,
     {
-        if !self.output_old_remove_me.ends_with('[') {
-            self.output_old_remove_me += ",";
-        }
-        value.serialize(&mut **self)
+        todo!()
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output_old_remove_me += "]";
-        Ok(())
+        todo!()
     }
 }
 
-// Tuple variants are a little different. Refer back to the
-// `serialize_tuple_variant` method above:
-//
-//    self.output_old_remove_me += "{";
-//    variant.serialize(&mut *self)?;
-//    self.output_old_remove_me += ":[";
-//
-// So the `end` method in this impl is responsible for closing both the `]` and
-// the `}`.
-impl<'a> ser::SerializeTupleVariant for &'a mut Serializer {
+impl<'a> ser::SerializeTupleVariant for &'a mut MySerializer {
     type Ok = ();
     type Error = DbError;
 
-    fn serialize_field<T>(&mut self, value: &T) -> Result<(), DbError>
+    fn serialize_field<T>(&mut self, _value: &T) -> Result<(), DbError>
     where
         T: ?Sized + Serialize,
     {
-        if !self.output_old_remove_me.ends_with('[') {
-            self.output_old_remove_me += ",";
-        }
-        value.serialize(&mut **self)
+        todo!()
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output_old_remove_me += "]}";
-        Ok(())
+        todo!()
     }
 }
 
-// Some `Serialize` types are not able to hold a key and value in memory at the
-// same time so `SerializeMap` implementations are required to support
-// `serialize_key` and `serialize_value` individually.
-//
-// There is a third optional method on the `SerializeMap` trait. The
-// `serialize_entry` method allows serializers to optimize for the case where
-// key and value are both available simultaneously. In JSON it doesn't make a
-// difference so the default behavior for `serialize_entry` is fine.
-impl<'a> ser::SerializeMap for &'a mut Serializer {
+impl<'a> ser::SerializeMap for &'a mut MySerializer {
     type Ok = ();
     type Error = DbError;
 
-    // The Serde data model allows map keys to be any serializable type. JSON
-    // only allows string keys so the implementation below will produce invalid
-    // JSON if the key serializes as something other than a string.
-    //
-    // A real JSON serializer would need to validate that map keys are strings.
-    // This can be done by using a different Serializer to serialize the key
-    // (instead of `&mut **self`) and having that other serializer only
-    // implement `serialize_str` and return an error on any other data type.
-    fn serialize_key<T>(&mut self, key: &T) -> Result<(), DbError>
+    fn serialize_key<T>(&mut self, _key: &T) -> Result<(), DbError>
     where
         T: ?Sized + Serialize,
     {
-        if !self.output_old_remove_me.ends_with('{') {
-            self.output_old_remove_me += ",";
-        }
-        key.serialize(&mut **self)
+        todo!()
     }
 
-    // It doesn't make a difference whether the colon is printed at the end of
-    // `serialize_key` or at the beginning of `serialize_value`. In this case
-    // the code is a bit simpler having it here.
-    fn serialize_value<T>(&mut self, value: &T) -> Result<(), DbError>
+    fn serialize_value<T>(&mut self, _value: &T) -> Result<(), DbError>
     where
         T: ?Sized + Serialize,
     {
-        self.output_old_remove_me += ":";
-        value.serialize(&mut **self)
+        todo!()
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output_old_remove_me += "}";
-        Ok(())
+        todo!()
     }
 }
 
-// Structs are like maps in which the keys are constrained to be compile-time
-// constant strings.
-impl<'a> ser::SerializeStruct for &'a mut Serializer {
+impl<'a> ser::SerializeStruct for &'a mut MySerializer {
     type Ok = ();
     type Error = DbError;
 
@@ -539,769 +322,29 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if !self.output_old_remove_me.ends_with('{') {
-            self.output_old_remove_me += ",";
-        }
-        key.serialize(&mut **self)?;
-        self.output_old_remove_me += ":";
-        value.serialize(&mut **self)
+        self.keys.push(key.to_string());
+        value.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output_old_remove_me += "}";
         Ok(())
     }
 }
 
-// Similar to `SerializeTupleVariant`, here the `end` method is responsible for
-// closing both of the curly braces opened by `serialize_struct_variant`.
-impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
+impl<'a> ser::SerializeStructVariant for &'a mut MySerializer {
     type Ok = ();
     type Error = DbError;
 
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), DbError>
+    fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<(), DbError>
     where
         T: ?Sized + Serialize,
     {
-        if !self.output_old_remove_me.ends_with('{') {
-            self.output_old_remove_me += ",";
-        }
-        key.serialize(&mut **self)?;
-        self.output_old_remove_me += ":";
-        value.serialize(&mut **self)
+        todo!()
     }
 
     fn end(self) -> Result<(), DbError> {
-        self.output_old_remove_me += "}}";
-        Ok(())
-    }
-}
-
-// Deserialization
-
-#[derive(Debug)]
-pub struct Deserializer<'de> {
-    // This string starts with the input data and characters are truncated off
-    // the beginning as data is parsed.
-    input: &'de str,
-    _input_new: DbRow,
-}
-
-impl<'de> Deserializer<'de> {
-    // By convention, `Deserializer` constructors are named like `from_xyz`.
-    // That way basic use cases are satisfied by something like
-    // `serde_json::from_str(...)` while advanced use cases that require a
-    // deserializer can make one with `serde_json::Deserializer::from_str(...)`.
-    // // pub fn from_str(input: &'de str) -> Self {
-    // //     Deserializer {
-    // //         input,
-    // //         _input_new: DbRow::new(),
-    // //     }
-    // // }
-}
-
-// By convention, the public API of a Serde deserializer is one or more
-// `from_xyz` methods such as `from_str`, `from_bytes`, or `from_reader`
-// depending on what Rust types the deserializer is able to consume as input.
-
-// // This basic deserializer supports only `from_str`.
-// pub fn from_str<'a, T>(s: &'a str) -> Result<T, DbError>
-// where
-//     T: Deserialize<'a>,
-// {
-//     let mut deserializer = Deserializer::from_str(s);
-//     let t = T::deserialize(&mut deserializer)?;
-//     if deserializer.input.is_empty() {
-//         Ok(t)
-//     } else {
-//         Err(DbError::SerdeError(
-//             "Deserialization error: TrailingCharacters".to_string(),
-//         ))
-//     }
-// }
-
-pub fn from_db_row<T>(db_row: &DbRow) -> Result<T, DbError>
-where
-    T: for<'a> Deserialize<'a>,
-{
-    // TODO: This is a very inefficient way of deserializing a DbRow to a struct, but it works.
-    // We need to eliminate the dependency on serde_json and deserialize the DbRow directly to the
-    // struct rather than first to a String.
-
-    let string_row = to_string(db_row).unwrap();
-    let value: JsonValue = serde_json::from_str(&string_row).unwrap();
-    let json_row: JsonRow = value.as_object().unwrap().clone();
-
-    let mut flat_json_row = JsonRow::new();
-    for (column, value) in json_row.iter() {
-        //println!("VALUE: {value:?}");
-        match value.as_object() {
-            Some(value) => {
-                assert_eq!(value.len(), 1);
-                let value = value.iter().collect::<Vec<_>>()[0];
-                let value_type = value.0;
-                let value_value = JsonValue::from(value.1.clone());
-                match value_type.to_lowercase().as_str() {
-                    "null" => flat_json_row.insert(column.to_string(), JsonValue::Null),
-                    "boolean" => flat_json_row.insert(column.to_string(), value_value),
-                    "smallinteger" => flat_json_row.insert(column.to_string(), value_value),
-                    "integer" => flat_json_row.insert(column.to_string(), value_value),
-                    "biginteger" => flat_json_row.insert(column.to_string(), value_value),
-                    "real" => flat_json_row.insert(column.to_string(), value_value),
-                    "bigreal" => flat_json_row.insert(column.to_string(), value_value),
-                    "numeric" => flat_json_row.insert(column.to_string(), value_value),
-                    "text" => flat_json_row.insert(column.to_string(), value_value),
-                    _ => panic!(),
-                }
-            }
-            None => flat_json_row.insert(column.to_string(), JsonValue::from(value.clone())),
-        };
-    }
-    let flat_string_row = format!("{}", serde_json::json!(flat_json_row));
-    let t_struct: T = serde_json::from_str(&flat_string_row).unwrap();
-    Ok(t_struct)
-}
-
-// SERDE IS NOT A PARSING LIBRARY. This impl block defines a few basic parsing
-// functions from scratch. More complicated formats may wish to use a dedicated
-// parsing library to help implement their Serde deserializer.
-impl<'de> Deserializer<'de> {
-    // Look at the first character in the input without consuming it.
-    fn peek_char(&mut self) -> Result<char, DbError> {
-        self.input.chars().next().ok_or(DbError::SerdeError(
-            "Deserialization error: EoF".to_string(),
-        ))
-    }
-
-    // Consume the first character in the input.
-    fn next_char(&mut self) -> Result<char, DbError> {
-        let ch = self.peek_char()?;
-        self.input = &self.input[ch.len_utf8()..];
-        Ok(ch)
-    }
-
-    // Parse the JSON identifier `true` or `false`.
-    fn parse_bool(&mut self) -> Result<bool, DbError> {
-        if self.input.starts_with("true") {
-            self.input = &self.input["true".len()..];
-            Ok(true)
-        } else if self.input.starts_with("false") {
-            self.input = &self.input["false".len()..];
-            Ok(false)
-        } else {
-            Err(DbError::SerdeError(
-                "Deserialization error: ExpectedBoolean".to_string(),
-            ))
-        }
-    }
-
-    // Parse a group of decimal digits as an unsigned integer of type T.
-    //
-    // This implementation is a bit too lenient, for example `001` is not
-    // allowed in JSON. Also the various arithmetic operations can overflow and
-    // panic or return bogus data. But it is good enough for example code!
-    fn parse_unsigned<T>(&mut self) -> Result<T, DbError>
-    where
-        T: AddAssign<T> + MulAssign<T> + From<u8>,
-    {
-        let mut int = match self.next_char()? {
-            ch @ '0'..='9' => T::from(ch as u8 - b'0'),
-            _ => {
-                return Err(DbError::SerdeError(
-                    "Deserialization error: ExpectedInteger".to_string(),
-                ));
-            }
-        };
-        loop {
-            match self.input.chars().next() {
-                Some(ch @ '0'..='9') => {
-                    self.input = &self.input[1..];
-                    int *= T::from(10);
-                    int += T::from(ch as u8 - b'0');
-                }
-                _ => {
-                    return Ok(int);
-                }
-            }
-        }
-    }
-
-    // Parse a possible minus sign followed by a group of decimal digits as a
-    // signed integer of type T.
-    fn parse_signed<T>(&mut self) -> Result<T, DbError>
-    where
-        T: Neg<Output = T> + AddAssign<T> + MulAssign<T> + From<i8>,
-    {
-        // Optional minus sign, delegate to `parse_unsigned`, negate if negative.
-        unimplemented!()
-    }
-
-    // Parse a string until the next '"' character.
-    //
-    // Makes no attempt to handle escape sequences. What did you expect? This is
-    // example code!
-    fn parse_string(&mut self) -> Result<&'de str, DbError> {
-        if self.next_char()? != '"' {
-            return Err(DbError::SerdeError(
-                "Deserialization error: ExpectedString".to_string(),
-            ));
-        }
-        match self.input.find('"') {
-            Some(len) => {
-                let s = &self.input[..len];
-                self.input = &self.input[len + 1..];
-                Ok(s)
-            }
-            None => Err(DbError::SerdeError(
-                "Deserialization error: EoF".to_string(),
-            )),
-        }
-    }
-}
-
-impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
-    type Error = DbError;
-
-    // Look at the input data to decide what Serde data model type to
-    // deserialize as. Not all data formats are able to support this operation.
-    // Formats that support `deserialize_any` are known as self-describing.
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        match self.peek_char()? {
-            'n' => self.deserialize_unit(visitor),
-            't' | 'f' => self.deserialize_bool(visitor),
-            '"' => self.deserialize_str(visitor),
-            '0'..='9' => self.deserialize_u64(visitor),
-            '-' => self.deserialize_i64(visitor),
-            '[' => self.deserialize_seq(visitor),
-            '{' => {
-                println!("IN DESERIALIZE_ANY");
-                self.deserialize_map(visitor)
-            }
-            _ => Err(DbError::SerdeError(
-                "Deserialization error: ErrorSyntax".to_string(),
-            )),
-        }
-    }
-
-    // Uses the `parse_bool` parsing function defined above to read the JSON
-    // identifier `true` or `false` from the input.
-    //
-    // Parsing refers to looking at the input and deciding that it contains the
-    // JSON value `true` or `false`.
-    //
-    // Deserialization refers to mapping that JSON value into Serde's data
-    // model by invoking one of the `Visitor` methods. In the case of JSON and
-    // bool that mapping is straightforward so the distinction may seem silly,
-    // but in other cases Deserializers sometimes perform non-obvious mappings.
-    // For example the TOML format has a Datetime type and Serde's data model
-    // does not. In the `toml` crate, a Datetime in the input is deserialized by
-    // mapping it to a Serde data model "struct" type with a special name and a
-    // single field containing the Datetime represented as a string.
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_bool(self.parse_bool()?)
-    }
-
-    // The `parse_signed` function is generic over the integer type `T` so here
-    // it is invoked with `T=i8`. The next 8 methods are similar.
-    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_i8(self.parse_signed()?)
-    }
-
-    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_i16(self.parse_signed()?)
-    }
-
-    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_i32(self.parse_signed()?)
-    }
-
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_i64(self.parse_signed()?)
-    }
-
-    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_u8(self.parse_unsigned()?)
-    }
-
-    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_u16(self.parse_unsigned()?)
-    }
-
-    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_u32(self.parse_unsigned()?)
-    }
-
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_u64(self.parse_unsigned()?)
-    }
-
-    // Float parsing is stupidly hard.
-    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        unimplemented!()
-    }
-
-    // Float parsing is stupidly hard.
-    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        unimplemented!()
-    }
-
-    // The `Serializer` implementation on the previous page serialized chars as
-    // single-character strings so handle that representation here.
-    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        // Parse a string, check that it is one character, call `visit_char`.
-        unimplemented!()
-    }
-
-    // Refer to the "Understanding deserializer lifetimes" page for information
-    // about the three deserialization flavors of strings in Serde.
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_borrowed_str(self.parse_string()?)
-    }
-
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_str(visitor)
-    }
-
-    // The `Serializer` implementation on the previous page serialized byte
-    // arrays as JSON arrays of bytes. Handle that representation here.
-    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        unimplemented!()
-    }
-
-    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        unimplemented!()
-    }
-
-    // An absent optional is represented as the JSON `null` and a present
-    // optional is represented as just the contained value.
-    //
-    // As commented in `Serializer` implementation, this is a lossy
-    // representation. For example the values `Some(())` and `None` both
-    // serialize as just `null`. Unfortunately this is typically what people
-    // expect when working with JSON. Other formats are encouraged to behave
-    // more intelligently if possible.
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        if self.input.starts_with("null") {
-            self.input = &self.input["null".len()..];
-            visitor.visit_none()
-        } else {
-            visitor.visit_some(self)
-        }
-    }
-
-    // In Serde, unit means an anonymous value containing no data.
-    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        if self.input.starts_with("null") {
-            self.input = &self.input["null".len()..];
-            visitor.visit_unit()
-        } else {
-            Err(DbError::SerdeError(
-                "Deserialization error: ExpectedNull".to_string(),
-            ))
-        }
-    }
-
-    // Unit struct means a named value containing no data.
-    fn deserialize_unit_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_unit(visitor)
-    }
-
-    // As is done here, serializers are encouraged to treat newtype structs as
-    // insignificant wrappers around the data they contain. That means not
-    // parsing anything other than the contained value.
-    fn deserialize_newtype_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_newtype_struct(self)
-    }
-
-    // Deserialization of compound types like sequences and maps happens by
-    // passing the visitor an "Access" object that gives it the ability to
-    // iterate through the data contained in the sequence.
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        // Parse the opening bracket of the sequence.
-        if self.next_char()? == '[' {
-            // Give the visitor access to each element of the sequence.
-            let value = visitor.visit_seq(CommaSeparated::new(self))?;
-            // Parse the closing bracket of the sequence.
-            if self.next_char()? == ']' {
-                Ok(value)
-            } else {
-                Err(DbError::SerdeError(
-                    "Deserialization error: ExpectedArrayEnd".to_string(),
-                ))
-            }
-        } else {
-            Err(DbError::SerdeError(
-                "Deserialization error: ExpectedArray".to_string(),
-            ))
-        }
-    }
-
-    // Tuples look just like sequences in JSON. Some formats may be able to
-    // represent tuples more efficiently.
-    //
-    // As indicated by the length parameter, the `Deserialize` implementation
-    // for a tuple in the Serde data model is required to know the length of the
-    // tuple before even looking at the input data.
-    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    // Tuple structs look just like sequences in JSON.
-    fn deserialize_tuple_struct<V>(
-        self,
-        _name: &'static str,
-        _len: usize,
-        visitor: V,
-    ) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    // Much like `deserialize_seq` but calls the visitors `visit_map` method
-    // with a `MapAccess` implementation, rather than the visitor's `visit_seq`
-    // method with a `SeqAccess` implementation.
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        // Parse the opening brace of the map.
-        if self.next_char()? == '{' {
-            // Give the visitor access to each entry of the map.
-            let value = visitor.visit_map(CommaSeparated::new(self))?;
-            // Parse the closing brace of the map.
-            if self.next_char()? == '}' {
-                Ok(value)
-            } else {
-                Err(DbError::SerdeError(
-                    "Deserialization error: ExpectedMapEnd".to_string(),
-                ))
-            }
-        } else {
-            Err(DbError::SerdeError(
-                "Deserialization error: ExpectedMap".to_string(),
-            ))
-        }
-    }
-
-    // Structs look just like maps in JSON.
-    //
-    // Notice the `fields` parameter - a "struct" in the Serde data model means
-    // that the `Deserialize` implementation is required to know what the fields
-    // are before even looking at the input data. Any key-value pairing in which
-    // the fields cannot be known ahead of time is probably a map.
-    fn deserialize_struct<V>(
-        self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        println!("IN DESERIALIZE_STRUCT");
-        self.deserialize_map(visitor)
-    }
-
-    fn deserialize_enum<V>(
-        self,
-        _name: &'static str,
-        _variants: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        if self.peek_char()? == '"' {
-            // Visit a unit variant.
-            visitor.visit_enum(self.parse_string()?.into_deserializer())
-        } else if self.next_char()? == '{' {
-            // Visit a newtype variant, tuple variant, or struct variant.
-            let value = visitor.visit_enum(Enum::new(self))?;
-            // Parse the matching close brace.
-            if self.next_char()? == '}' {
-                Ok(value)
-            } else {
-                Err(DbError::SerdeError(
-                    "Deserialization error: ExpectedMapEnd".to_string(),
-                ))
-            }
-        } else {
-            Err(DbError::SerdeError(
-                "Deserialization error: ExpectedMap".to_string(),
-            ))
-        }
-    }
-
-    // An identifier in Serde is the type that identifies a field of a struct or
-    // the variant of an enum. In JSON, struct fields and enum variants are
-    // represented as strings. In other formats they may be represented as
-    // numeric indices.
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_str(visitor)
-    }
-
-    // Like `deserialize_any` but indicates to the `Deserializer` that it makes
-    // no difference which `Visitor` method is called because the data is
-    // ignored.
-    //
-    // Some deserializers are able to implement this more efficiently than
-    // `deserialize_any`, for example by rapidly skipping over matched
-    // delimiters without paying close attention to the data in between.
-    //
-    // Some formats are not able to implement this at all. Formats that can
-    // implement `deserialize_any` and `deserialize_ignored_any` are known as
-    // self-describing.
-    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_any(visitor)
-    }
-}
-
-// In order to handle commas correctly when deserializing a JSON array or map,
-// we need to track whether we are on the first element or past the first
-// element.
-struct CommaSeparated<'a, 'de: 'a> {
-    de: &'a mut Deserializer<'de>,
-    first: bool,
-}
-
-impl<'a, 'de> CommaSeparated<'a, 'de> {
-    fn new(de: &'a mut Deserializer<'de>) -> Self {
-        CommaSeparated { de, first: true }
-    }
-}
-
-// `SeqAccess` is provided to the `Visitor` to give it the ability to iterate
-// through elements of the sequence.
-impl<'de, 'a> SeqAccess<'de> for CommaSeparated<'a, 'de> {
-    type Error = DbError;
-
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, DbError>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        // Check if there are no more elements.
-        if self.de.peek_char()? == ']' {
-            return Ok(None);
-        }
-        // Comma is required before every element except the first.
-        if !self.first && self.de.next_char()? != ',' {
-            return Err(DbError::SerdeError(
-                "Deserialization error: ExpectedArrayComma".to_string(),
-            ));
-        }
-        self.first = false;
-        // Deserialize an array element.
-        seed.deserialize(&mut *self.de).map(Some)
-    }
-}
-
-// `MapAccess` is provided to the `Visitor` to give it the ability to iterate
-// through entries of the map.
-impl<'de, 'a> MapAccess<'de> for CommaSeparated<'a, 'de> {
-    type Error = DbError;
-
-    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, DbError>
-    where
-        K: DeserializeSeed<'de>,
-    {
-        // Check if there are no more entries.
-        if self.de.peek_char()? == '}' {
-            return Ok(None);
-        }
-        // Comma is required before every entry except the first.
-        if !self.first && self.de.next_char()? != ',' {
-            return Err(DbError::SerdeError(
-                "Deserialization error: ExpectedMapComma".to_string(),
-            ));
-        }
-        self.first = false;
-        // Deserialize a map key.
-        seed.deserialize(&mut *self.de).map(Some)
-    }
-
-    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, DbError>
-    where
-        V: DeserializeSeed<'de>,
-    {
-        // It doesn't make a difference whether the colon is parsed at the end
-        // of `next_key_seed` or at the beginning of `next_value_seed`. In this
-        // case the code is a bit simpler having it here.
-        if self.de.next_char()? != ':' {
-            return Err(DbError::SerdeError(
-                "Deserialization error: ExpectedMapColon".to_string(),
-            ));
-        }
-        // Deserialize a map value.
-        seed.deserialize(&mut *self.de)
-    }
-}
-
-struct Enum<'a, 'de: 'a> {
-    de: &'a mut Deserializer<'de>,
-}
-
-impl<'a, 'de> Enum<'a, 'de> {
-    fn new(de: &'a mut Deserializer<'de>) -> Self {
-        Enum { de }
-    }
-}
-
-// `EnumAccess` is provided to the `Visitor` to give it the ability to determine
-// which variant of the enum is supposed to be deserialized.
-//
-// Note that all enum deserialization methods in Serde refer exclusively to the
-// "externally tagged" enum representation.
-impl<'de, 'a> EnumAccess<'de> for Enum<'a, 'de> {
-    type Variant = Self;
-    type Error = DbError;
-
-    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), DbError>
-    where
-        V: DeserializeSeed<'de>,
-    {
-        // The `deserialize_enum` method parsed a `{` character so we are
-        // currently inside of a map. The seed will be deserializing itself from
-        // the key of the map.
-        let val = seed.deserialize(&mut *self.de)?;
-        // Parse the colon separating map key from value.
-        if self.de.next_char()? == ':' {
-            Ok((val, self))
-        } else {
-            Err(DbError::SerdeError(
-                "Deserialization error: ExpectedMapColon".to_string(),
-            ))
-        }
-    }
-}
-
-// `VariantAccess` is provided to the `Visitor` to give it the ability to see
-// the content of the single variant that it decided to deserialize.
-impl<'de, 'a> VariantAccess<'de> for Enum<'a, 'de> {
-    type Error = DbError;
-
-    // If the `Visitor` expected this variant to be a unit variant, the input
-    // should have been the plain string case handled in `deserialize_enum`.
-    fn unit_variant(self) -> Result<(), DbError> {
-        Err(DbError::SerdeError(
-            "Deserialization error: ExpectedString".to_string(),
-        ))
-    }
-
-    // Newtype variants are represented in JSON as `{ NAME: VALUE }` so
-    // deserialize the value here.
-    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, DbError>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        seed.deserialize(self.de)
-    }
-
-    // Tuple variants are represented in JSON as `{ NAME: [DATA...] }` so
-    // deserialize the sequence of data here.
-    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        de::Deserializer::deserialize_seq(self.de, visitor)
-    }
-
-    // Struct variants are represented in JSON as `{ NAME: { K: V, ... } }` so
-    // deserialize the inner map here.
-    fn struct_variant<V>(
-        self,
-        _fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, DbError>
-    where
-        V: Visitor<'de>,
-    {
-        println!("IN STRUCT_VARIANT");
-        de::Deserializer::deserialize_map(self.de, visitor)
+        todo!()
     }
 }
 
@@ -1309,31 +352,20 @@ impl<'de, 'a> VariantAccess<'de> for Enum<'a, 'de> {
 mod tests {
     use super::*;
     use crate::{db_row, db_value::DbValue};
+    // use rust_decimal::{Decimal, dec};
 
     #[test]
     fn test_serde_struct() {
-        // Serializing or deserializing a DbRow into a DbRow should yield a DbRow that is
-        // identical to the original one:
-        let db_row = db_row! {"value".into() => DbValue::from("foo")};
-        assert_eq!(db_row, to_db_row(&db_row).unwrap());
-        // TODO: Not yet working,
-        //assert_eq!(db_row, from_db_row(&db_row).unwrap());
-
-        // TODO: Because we are relying on JSON serialization it is impossible to distinguish
-        // between different types of numbers. So for now we are setting all of the struct's
-        // number fields to i64. Once we remove the serde_json dependency we will need to test
-        // structs that have many types of numbers.
-
         // Serializing and deserializing an arbitrary struct to a DbRow:
-        #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+        #[derive(Serialize, PartialEq, Debug, Clone)]
         struct TestStruct {
             boolean: bool,
-            smallint: i64,    // TODO: i16
-            mediumint: i64,   // TODO: i32
-            bigint: i64,      // TODO: i64
-            smallfloat: i64,  // TODO: f32
-            bigfloat: i64,    // TODO: f64
-            biggerfloat: i64, // TODO: decimal
+            smallint: i16,
+            mediumint: i32,
+            bigint: i64,
+            smallfloat: f32,
+            bigfloat: f64,
+            // biggerfloat: Decimal,
             text: String,
         }
 
@@ -1342,23 +374,30 @@ mod tests {
             smallint: 1,
             mediumint: 1,
             bigint: 1,
-            smallfloat: 1,
-            bigfloat: 1,
-            biggerfloat: 1,
+            smallfloat: 1_f32,
+            bigfloat: 1_f64,
+            // biggerfloat: dec!(1),
             text: 1.to_string(),
         };
 
         let expected_db_row = db_row! {
             "boolean".into() => DbValue::from(true),
-            "smallint".into() => DbValue::from(1_i64),
-            "mediumint".into() => DbValue::from(1_i64),
+            "smallint".into() => DbValue::from(1_i16),
+            "mediumint".into() => DbValue::from(1_i32),
             "bigint".into() => DbValue::from(1_i64),
-            "smallfloat".into() => DbValue::from(1_i64),
-            "bigfloat".into() => DbValue::from(1_i64),
-            "biggerfloat".into() => DbValue::from(1_i64),
+            "smallfloat".into() => DbValue::from(1_f32),
+            "bigfloat".into() => DbValue::from(1_f64),
+            // "biggerfloat".into() => DbValue::from(1_i64),
             "text".into() => DbValue::from("1"),
         };
         assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
-        assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
+        //assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
+
+        // Serializing or deserializing a DbRow into a DbRow should yield a DbRow that is
+        // identical to the original one:
+        //let db_row = db_row! {"value".into() => DbValue::from("foo")};
+        //assert_eq!(db_row, to_db_row(&db_row).unwrap());
+        // TODO: Not yet working,
+        //assert_eq!(db_row, from_db_row(&db_row).unwrap());
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -11,10 +11,6 @@ use serde::{
     ser,
 };
 
-////////////////////////////////////////////////////////////////////////////////
-// Serialization
-////////////////////////////////////////////////////////////////////////////////
-
 /// Convert the given struct to a [DbRow]. For this to be successful, the struct
 /// must be a "normal struct" of the form:
 ///
@@ -57,6 +53,79 @@ where
     }
     Ok(db_row)
 }
+
+/// Convert the given [DbRow] to a supported struct. For this to be successful,
+/// the struct must be a "normal struct" of the form:
+///
+/// struct NormalStruct {
+///   field1: type1,
+///   field2: type2,
+///   ...
+/// }
+///
+/// where type1, type2, ... are among the primitive types associated with
+/// the different kinds of [DbValue]. Other field types, and other types of
+/// structs (e.g., tuple structs, unit structs, see
+/// <https://doc.rust-lang.org/book/ch05-01-defining-structs.html>) are not
+/// supported and attempts to deserialize a [DbRow] to them will result in an
+/// error, as will attempts to deserialize a [DbRow] to anything other than a
+/// struct (e.g., an enum).
+pub fn from_db_row<T>(db_row: &DbRow) -> Result<T, DbError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let mut deserializer = DbRowDeserializer::from_db_row(db_row);
+    let t = T::deserialize(&mut deserializer)?;
+    if deserializer.keys.is_empty() && deserializer.values.is_empty() {
+        Ok(t)
+    } else {
+        Err(DbError::SerdeError(
+            "Deserialization error: Leftover input".to_string(),
+        ))
+    }
+}
+
+// TODO: Remove this alternative implementation of from_db_row() before merging this branch.
+// Keeping it around for now for comparison with the preferred implementaion.
+pub fn from_db_row_indirect<T>(db_row: &DbRow) -> Result<T, DbError>
+where
+    T: for<'a> Deserialize<'a>,
+{
+    // The method below *works* and, unlike the case of serializing a struct to a DbRow, where
+    // converting to JSON as an intermediate step necessarily throws away the type information
+    // that we need for a successful serialization to DbRow, in the case of deserialization,
+    // converting to JSON as an intermediate step is not lossy in that sense. So we do not
+    // *need* to find an alternative method. However converting to JSON first seems
+    // inefficient and it is probably be better to deserialize directly from a DbRow
+    // to a T struct, as is done in from_db_row() above.
+    let mut flat_row = JsonRow::new();
+    for (column, value) in db_row.iter() {
+        match value {
+            DbValue::Null => flat_row.insert(column.to_string(), JsonValue::Null),
+            DbValue::Boolean(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::SmallInteger(num) => {
+                flat_row.insert(column.to_string(), JsonValue::from(*num))
+            }
+            DbValue::Integer(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::BigInteger(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::Real(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::BigReal(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
+            DbValue::Numeric(num) => {
+                flat_row.insert(column.to_string(), JsonValue::from(num.to_f64()))
+            }
+            DbValue::Text(txt) => {
+                flat_row.insert(column.to_string(), JsonValue::from(txt.to_string()))
+            }
+        };
+    }
+    let t_struct: T = serde_json::from_str(&serde_json::json!(flat_row).to_string())
+        .map_err(|err| DbError::SerdeError(err.to_string()))?;
+    Ok(t_struct)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Serialization implementations
+////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug)]
 struct DbRowSerializer {
@@ -276,6 +345,81 @@ impl<'a> ser::Serializer for &'a mut DbRowSerializer {
     }
 }
 
+impl<'a> ser::SerializeStruct for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.keys.push(key.to_string());
+        value.serialize(&mut **self)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        Ok(())
+    }
+}
+
+impl<'a> ser::SerializeStructVariant for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        return Err(DbError::SerdeError(
+            "SerializeStructVariant::serialize_field() is not supported for DbRowSerializer"
+                .to_string(),
+        ));
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        return Err(DbError::SerdeError(
+            "SerializeStructVariant::end() is not supported for DbRowSerializer".to_string(),
+        ));
+    }
+}
+
+// Although a [DbRow] is essentially a wrapper around an IndexMap, when one is serialized,
+// the serialization begins with our implementation of SerializeStruct and thus does not require
+// us to explicitly implement actually working code for the implemetation of SerializeMap, because
+// the map is serialized, instead, via the call to value.serialize() (see above).
+impl<'a> ser::SerializeMap for &'a mut DbRowSerializer {
+    // These need to match the `Ok` and `Error` types of DbRowSerializer:
+    type Ok = ();
+    type Error = DbError;
+
+    fn serialize_key<T>(&mut self, _key: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        return Err(DbError::SerdeError(
+            "SerializeMap::serialize_key() is not supported for DbRowSerializer".to_string(),
+        ));
+    }
+
+    fn serialize_value<T>(&mut self, _value: &T) -> Result<(), DbError>
+    where
+        T: ?Sized + Serialize,
+    {
+        return Err(DbError::SerdeError(
+            "SerializeMap::serialize_value() is not supported for DbRowSerializer".to_string(),
+        ));
+    }
+
+    fn end(self) -> Result<(), DbError> {
+        return Err(DbError::SerdeError(
+            "SerializeMap::end() is not supported for DbRowSerializer".to_string(),
+        ));
+    }
+}
+
 impl<'a> ser::SerializeSeq for &'a mut DbRowSerializer {
     // These need to match the `Ok` and `Error` types of DbRowSerializer:
     type Ok = ();
@@ -362,152 +506,9 @@ impl<'a> ser::SerializeTupleVariant for &'a mut DbRowSerializer {
     }
 }
 
-// Although a [DbRow] is essentially a wrapper around an IndexMap, when one is serialized,
-// the serialization begins with our implementation of SerializeStruct and does not require
-// us to explicitly implement working code for SerializeMap.
-impl<'a> ser::SerializeMap for &'a mut DbRowSerializer {
-    // These need to match the `Ok` and `Error` types of DbRowSerializer:
-    type Ok = ();
-    type Error = DbError;
-
-    fn serialize_key<T>(&mut self, _key: &T) -> Result<(), DbError>
-    where
-        T: ?Sized + Serialize,
-    {
-        return Err(DbError::SerdeError(
-            "SerializeMap::serialize_key() is not supported for DbRowSerializer".to_string(),
-        ));
-    }
-
-    fn serialize_value<T>(&mut self, _value: &T) -> Result<(), DbError>
-    where
-        T: ?Sized + Serialize,
-    {
-        return Err(DbError::SerdeError(
-            "SerializeMap::serialize_value() is not supported for DbRowSerializer".to_string(),
-        ));
-    }
-
-    fn end(self) -> Result<(), DbError> {
-        return Err(DbError::SerdeError(
-            "SerializeMap::end() is not supported for DbRowSerializer".to_string(),
-        ));
-    }
-}
-
-impl<'a> ser::SerializeStruct for &'a mut DbRowSerializer {
-    // These need to match the `Ok` and `Error` types of DbRowSerializer:
-    type Ok = ();
-    type Error = DbError;
-
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), DbError>
-    where
-        T: ?Sized + Serialize,
-    {
-        self.keys.push(key.to_string());
-        value.serialize(&mut **self)?;
-        Ok(())
-    }
-
-    fn end(self) -> Result<(), DbError> {
-        Ok(())
-    }
-}
-
-impl<'a> ser::SerializeStructVariant for &'a mut DbRowSerializer {
-    // These need to match the `Ok` and `Error` types of DbRowSerializer:
-    type Ok = ();
-    type Error = DbError;
-
-    fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<(), DbError>
-    where
-        T: ?Sized + Serialize,
-    {
-        return Err(DbError::SerdeError(
-            "SerializeStructVariant::serialize_field() is not supported for DbRowSerializer"
-                .to_string(),
-        ));
-    }
-
-    fn end(self) -> Result<(), DbError> {
-        return Err(DbError::SerdeError(
-            "SerializeStructVariant::end() is not supported for DbRowSerializer".to_string(),
-        ));
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////
-// Deserialization
+// Deserialization implementations
 ////////////////////////////////////////////////////////////////////////////////
-
-/// Convert the given [DbRow] to a supported struct. For this to be successful,
-/// the struct must be a "normal struct" of the form:
-///
-/// struct NormalStruct {
-///   field1: type1,
-///   field2: type2,
-///   ...
-/// }
-///
-/// where type1, type2, ... are among the primitive types associated with
-/// the different kinds of [DbValue]. Other field types, and other types of
-/// structs (e.g., tuple structs, unit structs, see
-/// <https://doc.rust-lang.org/book/ch05-01-defining-structs.html>) are not
-/// supported and attempts to deserialize a [DbRow] to them will result in an
-/// error, as will attempts to deserialize a [DbRow] to anything other than a
-/// struct (e.g., an enum).
-pub fn from_db_row<T>(db_row: &DbRow) -> Result<T, DbError>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let mut deserializer = DbRowDeserializer::from_db_row(db_row);
-    let t = T::deserialize(&mut deserializer)?;
-    if deserializer.keys.is_empty() && deserializer.values.is_empty() {
-        Ok(t)
-    } else {
-        Err(DbError::SerdeError(
-            "Deserialization error: Leftover input".to_string(),
-        ))
-    }
-}
-
-// TODO: Remove this alternative implementation of from_db_row() before merging this branch.
-// Keeping it around for now for comparison with the preferred implementaion.
-pub fn from_db_row_indirect<T>(db_row: &DbRow) -> Result<T, DbError>
-where
-    T: for<'a> Deserialize<'a>,
-{
-    // The method below *works* and, unlike the case of serializing a struct to a DbRow, where
-    // converting to JSON as an intermediate step necessarily throws away the type information
-    // that we need for a successful serialization to DbRow, in the case of deserialization,
-    // converting to JSON as an intermediate step is not lossy in that sense. So we do not
-    // *need* to find an alternative method. However converting to JSON first seems
-    // inefficient and it is probably be better to deserialize directly from a DbRow
-    // to a T struct, as is done in from_db_row() above.
-    let mut flat_row = JsonRow::new();
-    for (column, value) in db_row.iter() {
-        match value {
-            DbValue::Null => flat_row.insert(column.to_string(), JsonValue::Null),
-            DbValue::Boolean(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::SmallInteger(num) => {
-                flat_row.insert(column.to_string(), JsonValue::from(*num))
-            }
-            DbValue::Integer(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::BigInteger(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::Real(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::BigReal(num) => flat_row.insert(column.to_string(), JsonValue::from(*num)),
-            DbValue::Numeric(num) => {
-                flat_row.insert(column.to_string(), JsonValue::from(num.to_f64()))
-            }
-            DbValue::Text(txt) => {
-                flat_row.insert(column.to_string(), JsonValue::from(txt.to_string()))
-            }
-        };
-    }
-    let t_struct: T = serde_json::from_str(&serde_json::json!(flat_row).to_string())
-        .map_err(|err| DbError::SerdeError(err.to_string()))?;
-    Ok(t_struct)
-}
 
 #[derive(Debug)]
 pub struct DbRowDeserializer<'de> {
@@ -808,8 +809,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let value = visitor.visit_map(self)?;
-        Ok(value)
+        visitor.visit_map(self)
     }
 
     fn deserialize_struct<V>(

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -3,7 +3,11 @@ use crate::{
     db_value::{DbRow, DbValue, JsonRow, JsonValue},
 };
 use rust_decimal::prelude::ToPrimitive;
-use serde::{Deserialize, Serialize, ser};
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Visitor},
+    ser,
+};
 
 pub fn to_db_row<T>(value: &T) -> Result<DbRow, DbError>
 where
@@ -35,15 +39,30 @@ where
 
 pub fn from_db_row<T>(db_row: &DbRow) -> Result<T, DbError>
 where
+    T: for<'de> Deserialize<'de>,
+{
+    let mut deserializer = MyDeserializer::from_db_row(db_row);
+    let t = T::deserialize(&mut deserializer)?;
+    if deserializer.keys.is_empty() && deserializer.values.is_empty() {
+        Ok(t)
+    } else {
+        Err(DbError::SerdeError(
+            "Deserialization error: Leftover input".to_string(),
+        ))
+    }
+}
+
+// TODO: Remove this function before merging this branch. Keeping it around for now for comparison.
+pub fn from_db_row_indirect<T>(db_row: &DbRow) -> Result<T, DbError>
+where
     T: for<'a> Deserialize<'a>,
 {
-    // TODO: Can we do this directly without the intermediate step of first converting to JSON?
     // The method below *works* and, unlike for serialization, where converting from JSON would
     // necessarily throw away type information, converting to JSON in this case does not throw
     // any type information away. So we do not *need* to find an alternative method. However this
     // method (using the intermediate step of deserializing to JSON) seems inefficient
-    // and it would probably be better to deserialize directly from a DbRow to a T struct if
-    // possible.
+    // and it is probably be better to deserialize directly from a DbRow to a T struct, as is done
+    // in from_db_row().
     let mut flat_row = JsonRow::new();
     for (column, value) in db_row.iter() {
         match value {
@@ -103,7 +122,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
 
     fn serialize_i8(self, _value: i8) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize an i8".to_string(),
+            "Serializing i8 is not supported".to_string(),
         ));
     }
 
@@ -124,7 +143,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
 
     fn serialize_u8(self, _value: u8) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a u8".to_string(),
+            "Serializing u8 is not supported".to_string(),
         ));
     }
 
@@ -155,7 +174,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
 
     fn serialize_char(self, _value: char) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a char".to_string(),
+            "Serializing char is not supported".to_string(),
         ));
     }
 
@@ -166,13 +185,13 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
 
     fn serialize_bytes(self, _values: &[u8]) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize bytes to a DbValue".to_string(),
+            "Serializing bytes is not supported".to_string(),
         ));
     }
 
     fn serialize_none(self) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize None".to_string(),
+            "Serializing None is not supported".to_string(),
         ));
     }
 
@@ -181,19 +200,19 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize Some".to_string(),
+            "Serializing Some is not supported".to_string(),
         ));
     }
 
     fn serialize_unit(self) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a unit".to_string(),
+            "Serializing unit is not supported".to_string(),
         ));
     }
 
     fn serialize_unit_struct(self, _name: &str) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a unit struct".to_string(),
+            "Serializing unit struct is not supported".to_string(),
         ));
     }
 
@@ -204,7 +223,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         _variant: &str,
     ) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a unit variant".to_string(),
+            "Serializing unit variant is not supported".to_string(),
         ));
     }
 
@@ -213,7 +232,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a newtype struct".to_string(),
+            "Serializing newtype struct is not supported".to_string(),
         ));
     }
 
@@ -228,19 +247,19 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a newtype variant".to_string(),
+            "Serializing newtype variant is not supported".to_string(),
         ));
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a seq".to_string(),
+            "Serializing seq is not supported".to_string(),
         ));
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a tuple".to_string(),
+            "Serializing tuple is not supported".to_string(),
         ));
     }
 
@@ -250,7 +269,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a tuple struct".to_string(),
+            "Serializing tuple struct is not supported".to_string(),
         ));
     }
 
@@ -262,7 +281,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a tuple variant".to_string(),
+            "Serializing tuple variant is not supported".to_string(),
         ));
     }
 
@@ -287,7 +306,7 @@ impl<'a> ser::Serializer for &'a mut MySerializer {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to serialize a struct variant".to_string(),
+            "Serializing struct variant is not supported".to_string(),
         ));
     }
 }
@@ -304,14 +323,14 @@ impl<'a> ser::SerializeSeq for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeSeq for MySerializer".to_string(),
+            "SerializeSeq::serialize_element() is not supported for MySerializer".to_string(),
         ));
     }
 
     // Close the sequence.
     fn end(self) -> Result<(), Self::Error> {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeSeq for MySerializer".to_string(),
+            "SerializeSeq::end() is not supported for MySerializer".to_string(),
         ));
     }
 }
@@ -325,13 +344,13 @@ impl<'a> ser::SerializeTuple for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeTuple for MySerializer".to_string(),
+            "SerializeTuple::serialize_element() is not supported for MySerializer".to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeTuple for MySerializer".to_string(),
+            "SerializeTuple::end() is not supported for MySerializer".to_string(),
         ));
     }
 }
@@ -345,13 +364,13 @@ impl<'a> ser::SerializeTupleStruct for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeTupleStruct for MySerializer".to_string(),
+            "SerializeTupleStruct::serialize_field() is not supported for MySerializer".to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeTupleStruct for MySerializer".to_string(),
+            "SerializeTupleStruct::end() is not supported for MySerializer".to_string(),
         ));
     }
 }
@@ -365,13 +384,14 @@ impl<'a> ser::SerializeTupleVariant for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeTupleVariant for MySerializer".to_string(),
+            "SerializeTupleVariant::serialize_field() is not supported for MySerializer"
+                .to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeTupleVariant for MySerializer".to_string(),
+            "SerializeTupleVariant::end() is not supported for MySerializer".to_string(),
         ));
     }
 }
@@ -385,7 +405,7 @@ impl<'a> ser::SerializeMap for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeMap for MySerializer".to_string(),
+            "SerializeMap::serialize_key() is not supported for MySerializer".to_string(),
         ));
     }
 
@@ -394,13 +414,13 @@ impl<'a> ser::SerializeMap for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeMap for MySerializer".to_string(),
+            "SerializeMap::serialize_value() is not supported for MySerializer".to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeMap for MySerializer".to_string(),
+            "SerializeMap::end() is not supported for MySerializer".to_string(),
         ));
     }
 }
@@ -432,14 +452,332 @@ impl<'a> ser::SerializeStructVariant for &'a mut MySerializer {
         T: ?Sized + Serialize,
     {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeStructVariant for MySerializer".to_string(),
+            "SerializeStructVariant::serialize_field() is not supported for MySerializer"
+                .to_string(),
         ));
     }
 
     fn end(self) -> Result<(), DbError> {
         return Err(DbError::SerdeError(
-            "I don't know how to implement SerializeStructVariant for MySerializer".to_string(),
+            "SerializeStructVariant::end() is not supported for MySerializer".to_string(),
         ));
+    }
+}
+
+#[derive(Debug)]
+pub struct MyDeserializer<'de> {
+    keys: Vec<&'de str>,
+    values: Vec<&'de DbValue>,
+}
+
+impl<'de> MyDeserializer<'de> {
+    pub fn from_db_row(input: &'de DbRow) -> Self {
+        MyDeserializer {
+            keys: input.map.keys().map(|s| s.as_str()).collect::<Vec<_>>(),
+            values: input.map.values().collect::<Vec<_>>(),
+        }
+    }
+
+    pub fn next_key(&mut self) -> Option<&'de str> {
+        self.keys.pop()
+    }
+
+    pub fn next_value(&mut self) -> Option<&'de DbValue> {
+        self.values.pop()
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut MyDeserializer<'de> {
+    type Error = DbError;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // TODO: Change the unimplemented!() calls to actual errors, like we do for
+        // unsupported serializations above.
+        // println!("In deserialize_any()");
+        unimplemented!()
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_bool()");
+        let value = self.next_value().unwrap().as_bool().unwrap();
+        visitor.visit_bool(value)
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_i8()");
+        unimplemented!()
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_i16()");
+        let value = self.next_value().unwrap().as_i16().unwrap();
+        visitor.visit_i16(value)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_i32()");
+        let value = self.next_value().unwrap().as_i32().unwrap();
+        visitor.visit_i32(value)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_i64()");
+        let value = self.next_value().unwrap().as_i64().unwrap();
+        visitor.visit_i64(value)
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_u8()");
+        unimplemented!()
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_u16()");
+        unimplemented!()
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_u32()");
+        unimplemented!()
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_u64()");
+        unimplemented!()
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_f32()");
+        let value = self.next_value().unwrap().as_f32().unwrap();
+        visitor.visit_f32(value)
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_f64()");
+        let value = self.next_value().unwrap().as_f64().unwrap();
+        visitor.visit_f64(value)
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_char()");
+        unimplemented!()
+    }
+
+    fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_string()");
+        unimplemented!()
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_string()");
+        let value = self.next_value().unwrap().as_str().unwrap();
+        visitor.visit_borrowed_str(value)
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_bytes()");
+        unimplemented!()
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_byte_buf()");
+        unimplemented!()
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_option()");
+        unimplemented!()
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_unit()");
+        unimplemented!()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_unit_struct()");
+        unimplemented!()
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_newtype_struct()");
+        unimplemented!()
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_seq()");
+        unimplemented!()
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_tuple()");
+        unimplemented!()
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_tuple_struct()");
+        unimplemented!()
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_map()");
+        let value = visitor.visit_map(self)?;
+        Ok(value)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_struct()");
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_enum()");
+        unimplemented!()
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // TODO: Remove unwraps here and elsewhere.
+        // println!("In deserialize_identifier()");
+        let key = self.next_key().unwrap();
+        visitor.visit_borrowed_str(key)
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, DbError>
+    where
+        V: Visitor<'de>,
+    {
+        // println!("In deserialize_ignored_any()");
+        unimplemented!()
+    }
+}
+
+impl<'de> de::MapAccess<'de> for MyDeserializer<'de> {
+    type Error = DbError;
+
+    fn next_key_seed<S>(&mut self, seed: S) -> Result<Option<S::Value>, Self::Error>
+    where
+        S: de::DeserializeSeed<'de>,
+    {
+        // println!("In next_key_seed() with SELF: {self:?}");
+        if self.keys.len() == 0 {
+            return Ok(None);
+        }
+        seed.deserialize(&mut *self).map(Some)
+    }
+
+    fn next_value_seed<S>(&mut self, seed: S) -> Result<S::Value, Self::Error>
+    where
+        S: de::DeserializeSeed<'de>,
+    {
+        // println!("In next_value_seed() with SELF: {self:?}");
+        seed.deserialize(&mut *self)
     }
 }
 
@@ -488,11 +826,9 @@ mod tests {
         };
         assert_eq!(expected_db_row, to_db_row(&expected_struct).unwrap());
         assert_eq!(expected_struct, from_db_row(&expected_db_row).unwrap());
-
-        // // Serializing or deserializing a DbRow into a DbRow should yield a DbRow that is
-        // // identical to the original one. TODO: This is not yet working.
-        // let db_row = db_row! {"value".into() => DbValue::from("foo")};
-        // assert_eq!(db_row, to_db_row(&db_row).unwrap());
-        // assert_eq!(db_row, from_db_row(&db_row).unwrap());
+        assert_eq!(
+            expected_struct,
+            from_db_row_indirect(&expected_db_row).unwrap()
+        );
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -572,8 +572,8 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut DbRowDeserializer<'de> {
             DbValue::Null => self.deserialize_unit(visitor),
             _ => {
                 let value = self.pop_value().unwrap();
-                let value = value.as_i16().unwrap();
-                visitor.visit_i16(value)
+                let value = value.as_i8().unwrap();
+                visitor.visit_i8(value)
             }
         }
     }

--- a/src/tokio_postgres.rs
+++ b/src/tokio_postgres.rs
@@ -420,8 +420,7 @@ impl DbQuery for TokioPostgresPool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::params;
-    use indexmap::indexmap as db_row;
+    use crate::{db_row, params};
     use pretty_assertions::assert_eq;
     use std::str::FromStr;
 

--- a/src/tokio_postgres.rs
+++ b/src/tokio_postgres.rs
@@ -455,7 +455,12 @@ mod tests {
             .query("SELECT MAX(int_value) FROM test_table_indirect", ())
             .await
             .unwrap();
-        assert_eq!(rows, [db_row! {"max".into() => DbValue::from(1_i64)}]);
+        assert_eq!(
+            rows,
+            [db_row! {
+                "max" => 1_i64,
+            }]
+        );
 
         // Test alias:
         let rows: Vec<DbRow> = pool
@@ -467,7 +472,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             rows,
-            [db_row! {"bool_value_alias".into() => DbValue::from(true)}]
+            [db_row! {
+                "bool_value_alias" => true,
+            }]
         );
 
         // Test aggregate with alias:
@@ -480,7 +487,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             rows,
-            [db_row! {"max_int_value".into() => DbValue::from(1_i64)}]
+            [db_row! {
+                "max_int_value" => 1_i64,
+            }]
         );
 
         // Test non-aggregate function:
@@ -491,7 +500,12 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(rows, [db_row! {"int_value".into() => DbValue::from("1")}]);
+        assert_eq!(
+            rows,
+            [db_row! {
+                "int_value" => "1",
+            }]
+        );
 
         // Test non-aggregate function with alias:
         let rows: Vec<DbRow> = pool
@@ -503,7 +517,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             rows,
-            [db_row! {"int_value_cast".into() => DbValue::from("1")}]
+            [db_row! {
+                "int_value_cast" => "1",
+            }]
         );
 
         // Clean up.

--- a/tests/axum.rs
+++ b/tests/axum.rs
@@ -4,11 +4,11 @@ use axum::{
     response::{Html, IntoResponse},
     routing::get,
 };
-use indexmap::indexmap;
 use rltbl_db::{
     any::AnyPool,
     core::DbQuery,
     db_kind::DbKind,
+    db_row,
     db_value::{DbRow, DbValue},
 };
 use std::{marker::Sync, sync::Arc};
@@ -39,7 +39,7 @@ async fn run_axum(url: &str) {
     pool.insert(
         "test",
         &["value"],
-        &[&indexmap! {"value".into() => DbValue::from("foo")}],
+        &[&db_row! {"value".into() => DbValue::from("foo")}],
     )
     .await
     .unwrap();

--- a/tests/axum.rs
+++ b/tests/axum.rs
@@ -4,13 +4,7 @@ use axum::{
     response::{Html, IntoResponse},
     routing::get,
 };
-use rltbl_db::{
-    any::AnyPool,
-    core::DbQuery,
-    db_kind::DbKind,
-    db_row,
-    db_value::{DbRow, DbValue},
-};
+use rltbl_db::{any::AnyPool, core::DbQuery, db_kind::DbKind, db_row, db_value::DbRow};
 use std::{marker::Sync, sync::Arc};
 use tower_service::Service;
 
@@ -39,7 +33,9 @@ async fn run_axum(url: &str) {
     pool.insert(
         "test",
         &["value"],
-        &[&db_row! {"value".into() => DbValue::from("foo")}],
+        &[&db_row! {
+            "value" => "foo",
+        }],
     )
     .await
     .unwrap();


### PR DESCRIPTION
@lmcmicu This is roughly how I'm hoping "inner" (de)serialization as JSON should work. It needs to be expanded to handle all the other "inner" types: enums, unit structs, newtype structs, tuple structs, and maybe seqs.

This isn't meant to be merged -- just a demonstration. Only commit 76a5b1f972e7db42696bdb988d4206e24086ceb9 is relevant. I should have branched from `serde-db-row` instead of `main`.